### PR TITLE
Clarify how to compile

### DIFF
--- a/doc_source/current-supported-versions.md
+++ b/doc_source/current-supported-versions.md
@@ -8,7 +8,7 @@ The underlying AWS Lambda execution environment is based on the following:
 
 +  Linux kernel version – 4\.9\.75\-25\.55\.amzn1\.x86\_64 
 
- If you are using any native binaries in your code, make sure they are compiled in this environment\. Note that only 64\-bit binaries are supported on AWS Lambda\.
+ If you are using any native binaries in your code, make sure they are compiled in this environment with no CPU optimizations\. Usage of CPU optimizations that are only available on certain EC2 instances may lead to unpredictable behavior as functions execute on heterogenuous hardware. Note that only 64\-bit binaries are supported on AWS Lambda\.
 
 AWS Lambda supports the following runtime versions:
 


### PR DESCRIPTION
Compiling your code on a fancy instance type with stuff like SSE2 can lead to intermittent errors if your function later runs on a T2.micro.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
