### PR TITLE
Change `go get` path in go package build

### DIFF
--- a/doc_source/lambda-go-how-to-create-deployment-package.md
+++ b/doc_source/lambda-go-how-to-create-deployment-package.md
@@ -4,7 +4,7 @@ To create a Lambda function you first create a Lambda function deployment packag
 
 After you create a deployment package, you may either upload it directly or upload the \.zip file first to an Amazon S3 bucket in the same AWS region where you want to create the Lambda function, and then specify the bucket name and object key name when you create the Lambda function using the console or the AWS CLI\.
 
- For Lambda functions written in Go, download the Lambda library for Go by navigating to the Go runtime directory and enter the following command:  `go get github.com/aws/aws-lambda-go` 
+ For Lambda functions written in Go, download the Lambda library for Go by navigating to the Go runtime directory and enter the following command:  `go get github.com/aws/aws-lambda-go/lambda` 
 
 Then use following command to build, package and deploy a Go Lambda function via the CLI\. Note that your *function\-name *must match the name of your *Lambda handler* name\. 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I believe the  `go get github.com/aws/aws-lambda-go` snippet should be  `go get github.com/aws/aws-lambda-go/lambda` otherwise go will error saying no go buildable Go source files in .... So I added /lambda to the code snippet. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
