### PR TITLE
Fix a small typo

### DIFF
--- a/doc_source/nodejs-prog-mode-exceptions.md
+++ b/doc_source/nodejs-prog-mode-exceptions.md
@@ -44,7 +44,7 @@ Again, when this Lambda function is invoked, it will notify AWS Lambda that func
 
 ```
 {
-  "errorMessage": "Acccount is in use!",
+  "errorMessage": "Account is in use!",
   "errorType": "Error",
   "stackTrace": [
     "exports.handler (/var/task/index.js:10:17)"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes a small typo in the NodeJS exceptions document.

`Acccount` => `Account`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
