### PR TITLE
Fix Issue #31 bug in Configuration on java-logging.md

### DIFF
--- a/doc_source/java-logging.md
+++ b/doc_source/java-logging.md
@@ -127,7 +127,7 @@ This section provides examples of using Custom Appender for Log4j and the `Lambd
 
     ```
      <?xml version="1.0" encoding="UTF-8"?>
-    <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2.LambdaAppender">
+    <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
       <Appenders>
         <Lambda name="Lambda">
           <PatternLayout>


### PR DESCRIPTION
When used as it was logging would produce this error 

    2018-04-23 14:04:19,908 main ERROR Error processing element Lambda ([Appenders: null]): CLASS_NOT_FOUND
    2018-04-23 14:04:19,926 main ERROR Unable to locate appender "Lambda" for logger config "root"

The problem was that the `packages` parameter to Configuration should be a comma separated list of package names not a class name. (see https://logging.apache.org/log4j/log4j-2.1/manual/configuration.html#ConfigurationSyntax )

 So i fixed that.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
