### PR TITLE
Linked CloudTrail docs for Lambda events

### DIFF
--- a/doc_source/logging-using-cloudtrail.md
+++ b/doc_source/logging-using-cloudtrail.md
@@ -99,7 +99,7 @@ The following example shows CloudTrail log entries for the `GetFunction` and `De
 ```
 
 **Note**  
-The `eventName` may include date and version information, such as `"GetFunction20150331"`, but it is still referring to the same public API\.
+The `eventName` may include date and version information, such as `"GetFunction20150331"`, but it is still referring to the same public API. For more information, see [Services Supported by CloudTrail Event History](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/view-cloudtrail-events-supported-services.html#view-cloudtrail-events-supported-apis-lambda) in the *AWS CloudTrail User Guide*\.
 
 ## Using CloudTrail to Track Function Invocations<a name="tracking-function-invocations"></a>
 


### PR DESCRIPTION
*Description of changes:* Added a link to CloudTrail docs for the Lambda events, which contains the list of the eventNames that have the date and version information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
