### PR TITLE
Reference non-deprecated gradle configuration

### DIFF
--- a/doc_source/create-deployment-pkg-zip-java.md
+++ b/doc_source/create-deployment-pkg-zip-java.md
@@ -55,7 +55,7 @@ After you build the project, the resulting \.zip file \(that is, your deployment
        from compileJava
        from processResources              
        into('lib') {
-           from configurations.runtime
+           from configurations.compileClasspath
        }           
    }
    


### PR DESCRIPTION
`runtime` has since been deprecated and it is now advised to use the `compileClasspath` configuration instead.  Using `runtime` will not actually include dependency jars in modern Gradle.

Tested on:
```
------------------------------------------------------------
Gradle 4.2
------------------------------------------------------------

Build time:   2017-09-20 14:48:23 UTC
Revision:     5ba503cc17748671c83ce35d7da1cffd6e24dfbd

Groovy:       2.4.11
Ant:          Apache Ant(TM) version 1.9.6 compiled on June 29 2015
JVM:          1.8.0_152 (Oracle Corporation 25.152-b16)
OS:           Mac OS X 10.13.4 x86_64
```

See [Gradle Docs on the Java plugin](https://docs.gradle.org/current/userguide/java_plugin.html?_ga=2.256911375.546221539.1525811785-1502963936.1524851754) for more info.