### PR TITLE
Fixing Go Tags

### DIFF
--- a/doc_source/go-programming-model-handler-types.md
+++ b/doc_source/go-programming-model-handler-types.md
@@ -54,12 +54,12 @@ import (
 )
  
 type MyEvent struct {
-        Name string 'json:"What is your name?"'
-        Age int     'json:"How old are you?"'
+        Name string `json:"What is your name?"`
+        Age int     `json:"How old are you?"`
 }
  
 type MyResponse struct {
-        Message string 'json:"Answer:"'
+        Message string `json:"Answer:"`
 }
  
 func HandleLambdaEvent(event MyEvent) (MyResponse, error) {


### PR DESCRIPTION
Using backtick in  Golang tags

Probably an typo error


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
