### PR TITLE
Fixed some context object's properties names in the code example box

### DIFF
--- a/doc_source/nodejs-prog-model-context.md
+++ b/doc_source/nodejs-prog-model-context.md
@@ -24,9 +24,9 @@ exports.handler = function(event, context, callback) {
     console.log('value3 =', event.key3);
     console.log('remaining time =', context.getRemainingTimeInMillis());
     console.log('functionName =', context.functionName);
-    console.log('AWSrequestID =', context.awsRequestId);
-    console.log('logGroupName =', context.log_group_name);
-    console.log('logStreamName =', context.log_stream_name);
+    console.log('awsRequestId =', context.awsRequestId);
+    console.log('logGroupName =', context.logGroupName);
+    console.log('logStreamName =', context.logStreamName);
     console.log('clientContext =', context.clientContext);
     if (typeof context.identity !== 'undefined') {
         console.log('Cognito


### PR DESCRIPTION
Fixed some context object's properties names in the example to make it work. Tested with both Node.js 6.10 and 8.10 and seems to be working fine.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
