### PR TITLE
Fix for wrong variable name

### DIFF
--- a/doc_source/with-kinesis-example-deployment-pkg.md
+++ b/doc_source/with-kinesis-example-deployment-pkg.md
@@ -179,7 +179,7 @@ Follow the instructions to create a AWS Lambda function deployment package\.
    func handler(ctx context.Context, kinesisEvent events.KinesisEvent) {
        for _, record := range kinesisEvent.Records {
            kinesisRecord := record.Kinesis
-           dataBytes := kinesisRecordData.Data
+           dataBytes := kinesisRecord.Data
            dataText := string(dataBytes)
    
            fmt.Printf("%s Data = %s \n", record.EventName, dataText) 


### PR DESCRIPTION
Kinesis record has a wrong name. The code won't compile.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
