### PR TITLE
Fix values for EvaluationPeriods and Period

### DIFF
--- a/doc_source/with-sched-event-example-use-app-spec.md
+++ b/doc_source/with-sched-event-example-use-app-spec.md
@@ -15,7 +15,7 @@ The following contains the SAM template for this application\. Copy the text bel
 ```
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Parameters: 
+Parameters:
   NotificationEmail:
     Type: String
 Resources:
@@ -47,10 +47,10 @@ Resources:
       Dimensions:
         - Name: FunctionName
           Value: !Ref CheckWebsitePeriodically
-      EvaluationPeriods: String
+      EvaluationPeriods: 1
       MetricName: Errors
       Namespace: AWS/Lambda
-      Period: '60'
+      Period: 60
       Statistic: Sum
       Threshold: '1'
 ```


### PR DESCRIPTION
Hello,

Looking at the docs for [AWS::CloudWatch::Alarm
](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html) i see that types for the following params 

```
EvaluationPeriods
Type: Integer
```

and 

```
Period
Type: Integer
```

but right now in the docs they are 

```
EvaluationPeriods: String
Period: '60'
```

So I've added changed to docs to be aligned with types.
Please let me know if this makes sense.

Thanks



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
