### PR TITLE
Fix wrong HTTP verb

### DIFF
--- a/doc_source/test-sam-cli.md
+++ b/doc_source/test-sam-cli.md
@@ -207,7 +207,7 @@ Resources:
 ```
 
 The preceding example configures the following RESTful API endpoints:
-+ Create a new product with a `PUT` request to /products\.
++ Create a new product with a `POST` request to /products\.
 + List all products with a `GET` request to /products\.
 + Read, update, or delete a product with `GET`, `PUT` or `DELETE` request to /products/\{product\}\.
 


### PR DESCRIPTION
HTTP `POST` should be used to create a product (like specified in the code example).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
