### PR TITLE
Correct link for GetFunction

### DIFF
--- a/doc_source/concurrent-executions.md
+++ b/doc_source/concurrent-executions.md
@@ -72,7 +72,7 @@ To remove a concurrency limit for your Lambda function using the AWS CLI, do the
   ```
 
 To view a concurrency limit for your Lambda function using the AWS CLI, do the following:
-+ Use the [GetFunction](API_GetFunctionConfiguration.md) operation and pass in the function name:
++ Use the [GetFunction](API_GetFunction.md) operation and pass in the function name:
 
   ```
   aws lambda get-function --function-name function-name  


### PR DESCRIPTION
Previously the link was going to https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionConfiguration.html which does not provide `Concurrency` information.

The correct link is https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.