### PR TITLE
Fixed an error in Gradle configuration

### DIFF
--- a/doc_source/create-deployment-pkg-zip-java.md
+++ b/doc_source/create-deployment-pkg-zip-java.md
@@ -55,7 +55,7 @@ After you build the project, the resulting \.zip file \(that is, your deployment
        from compileJava
        from processResources              
        into('lib') {
-           from configurations.compile.Classpath
+           from configurations.runtime.files
        }           
    }
    


### PR DESCRIPTION
The existing Gradle configuration for building a zip file was failing as it was wrong:

```
$ gradle -v
------------------------------------------------------------
Gradle 4.8
------------------------------------------------------------

Build time:   2018-06-04 10:39:58 UTC
Revision:     9e1261240e412cbf61a5e3a5ab734f232b2f887d

Groovy:       2.4.12
Ant:          Apache Ant(TM) version 1.9.11 compiled on March 23 2018
JVM:          1.8.0_171 (Oracle Corporation 25.171-b11)
OS:           Linux 4.15.0-23-generic amd64

./gradlew clean build
FAILURE: Build failed with an exception.

* Where:
Build file '/home/behrang/example/build.gradle' line: 36

* What went wrong:
A problem occurred evaluating root project 'example'.
> Could not get unknown property 'Classpath' for configuration ':compile' of type org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.
```

This patch fixes this error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
