### PR TITLE
SQS integration: Make Java example code work

### DIFF
--- a/doc_source/with-sqs-create-package.md
+++ b/doc_source/with-sqs-create-package.md
@@ -52,14 +52,14 @@ The following is example Java code that receives an Amazon SQS event message as 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSEventRecord;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 
         public class ProcessSQSEvents implements RequestHandler<SQSEvent, Void>{
             @Override
             public Void handleRequest(SQSEvent event, Context context)
             {
-                for(SQSEventRecord rec : event.getRecords()) {
-                    System.out.println(new String(rec.getSQS().getBody());
+                for(SQSMessage msg : event.getRecords()) {
+                    System.out.println(new String(msg.getBody()));
                 }
                 return null;
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes the Java example code to use SQS queue as an event source for AWS Labmda. The original example code couldn't be compiled because the class `SQSEventRecord` does not exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
