### PR TITLE
Remove spaces between values separated by commas

### DIFF
--- a/doc_source/tutorial-scheduled-events-schedule-expressions.md
+++ b/doc_source/tutorial-scheduled-events-schedule-expressions.md
@@ -63,7 +63,7 @@ The following table describes the wildcard characters\.
 |  \*  |  Specifies *All values*  |  If used in the Day\-of\-month field, it means all days in the month\.  | 
 |  ?  |  No specified value  |  Used in conjunction with another specified value\. For example, if a specific date is specified, but you don't care what day of the week it falls on\.  | 
 |  \-  |  Specifies ranges  |  `10-12` would mean 10, 11 and 12  | 
-|  ,  |  Specifies additional values  |  `SUN, MON, TUE` means Sunday, Monday and Tuesday  | 
+|  ,  |  Specifies additional values  |  `SUN,MON,TUE` means Sunday, Monday and Tuesday  | 
 |  /  |  Specifies increments  |  `5/10` means 5, 15, 25, 35, etc\.  | 
 
 The following table lists common examples of cron expressions\.


### PR DESCRIPTION
Remove spaces between values separated by commas as this is required when setting a schedule value.

e.g. `MON, TUE, THU` => `MON,TUE,THU`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.