### PR TITLE
Changed to formula for concurrent invocations

### DIFF
--- a/doc_source/scaling.md
+++ b/doc_source/scaling.md
@@ -3,7 +3,7 @@
 Concurrent executions refers to the number of executions of your function code that are happening at any given time\. You can estimate the concurrent execution count, but the concurrent execution count will differ depending on whether or not your Lambda function is processing events from a poll\-based event source\.  If you create a Lambda function to process events from event sources that aren't poll\-based \(for example, Lambda can process every event from other sources, like Amazon S3 or API Gateway\), each published event is a unit of work, in parallel, up to your account limits\. Therefore, the number of events \(or requests\) these event sources publish influences the concurrency\. You can use the this formula to estimate your concurrent Lambda function invocations: 
 
 ```
-events (or requests) per second * function duration
+events (or requests) per second * function duration (in seconds)
 ```
 
  For example, consider a Lambda function that processes Amazon S3 events\. Suppose that the Lambda function takes on average three seconds and Amazon S3 publishes 10 events per second\. Then, you will have 30 concurrent executions of your Lambda function\. 


### PR DESCRIPTION
Just a detail but it could possible confuse people otherwise...

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
