### PR TITLE
Update on execution context reuse with exceptions

### DIFF
--- a/doc_source/running-lambda-code.md
+++ b/doc_source/running-lambda-code.md
@@ -7,7 +7,10 @@ The content of this section is for information only\. AWS Lambda manages Executi
 
 It takes time to set up an Execution Context and do the necessary "bootstrapping", which adds some latency each time the Lambda function is invoked\. You typically see this latency when a Lambda function is invoked for the first time or after it has been updated because AWS Lambda tries to reuse the Execution Context for subsequent invocations of the Lambda function\.
 
-After a Lambda function is executed, AWS Lambda maintains the Execution Context for some time in anticipation of another Lambda function invocation\. In effect, the service freezes the Execution Context after a Lambda function completes, and thaws the context for reuse, if AWS Lambda chooses to reuse the context when the Lambda function is invoked again\. This Execution Context reuse approach has the following implications: 
+After a Lambda function is executed, AWS Lambda maintains the Execution Context for some time in anticipation of another Lambda function invocation\. In effect, the service freezes the Execution Context after a Lambda function completes, and thaws the context for reuse, if AWS Lambda chooses to reuse the context when the Lambda function is invoked again\. The Execution Context is frozen even if an exception is raised, but is discarded if your code explicitly exits the process.
+
+This Execution Context reuse approach has the following implications: 
+
 + Any declarations in your Lambda function code \(outside the `handler` code, see [Programming Model](programming-model-v2.md)\) remains initialized, providing additional optimization when the function is invoked again\. For example, if your Lambda function establishes a database connection, instead of reestablishing the connection, the original connection is used in subsequent invocations\. We suggest adding logic in your code to check if a connection exists before creating one\.
 
    


### PR DESCRIPTION
This is just based on my experience with Python, but initially I was under the impression that an exception caused the container to be shut down due to an error having occurred.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
