### PR TITLE
Update tutorial-env_cli.md

### DIFF
--- a/doc_source/tutorial-env_cli.md
+++ b/doc_source/tutorial-env_cli.md
@@ -27,15 +27,12 @@ The code sample below reads the environment variable of a Lambda function that r
 
 1. Open a text editor and copy the following code:
 
-   ```
-   var AWS = require('aws-sdk');
-        
-       exports.handler = function(event, context, callback) {
-           
-           var bucketName = process.env.S3_BUCKET;       
-       	callback(null, bucketName);        
-       }
-   ```
+```js
+exports.handler = function(event, context, callback) {
+  var bucketName = process.env.S3_BUCKET;
+  callback(null, bucketName);
+};
+```
 
 1.  Save the file as *index\.js*\. 
 


### PR DESCRIPTION
Hello,

I did some formatting on the lambda handler code and removed `aws-sdk` from imports as the example only reads value from environment variables and does nothing with `aws-sdk` itself. It might be confusing for people who start playing with Lambdas.

Please let me know if this makes sense.

Thanks


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
