### PR TITLE
Change the links to the Lambda Java libraries

### DIFF
--- a/doc_source/java-programming-model.md
+++ b/doc_source/java-programming-model.md
@@ -17,4 +17,4 @@ Additionally, note that AWS Lambda provides the following libraries:
 **Note**  
 Support for the Log4j v1\.2 custom appender is marked for End\-Of\-Life\. It will not receive ongoing updates and is not recommended for use\.
 
- These libraries are available through the [Maven Central Repository](https://maven.apache.org/) and can also be found on [GitHub](https://github.com/)\.
+ These libraries are available through the [Maven Central Repository](https://search.maven.org/search?q=g:com.amazonaws) and can also be found on [GitHub](https://github.com/aws/aws-lambda-java-libs)\.


### PR DESCRIPTION
*Description of changes:*

Instead of linking to the front pages of Maven Central and GitHub, link to a search that includes the libraries mentioned in the docs, and link directly to the repository on GitHub.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
