### PR TITLE
Tweak the initialization error request example

### DIFF
--- a/doc_source/runtimes-api.md
+++ b/doc_source/runtimes-api.md
@@ -94,10 +94,9 @@ curl -X POST "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/$RE
 
 If the runtime encounters an error during initialization, it posts an error message to the initialization error path\.
 
-**Example Error Request**  
+**Example Initialization Error Request**
 
 ```
-REQUEST_ID=156cb537-e2d4-11e8-9b34-d36013741fb9
-#ERROR="{\"errorMessage\" : \"Failed to load function.\", \"errorType\" : \"InvalidFunctionException\"}"
-#curl -X POST "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/init/error"  -d "$ERROR"
+ERROR="{\"errorMessage\" : \"Failed to load function.\", \"errorType\" : \"InvalidFunctionException\"}"
+curl -X POST "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/init/error"  -d "$ERROR"
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The `REQUEST_ID` is not applicable to the initialization error requests, so just adds noise. And the way the remaining lines were commented-out was not consistent with all other exmaples on the page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.