### PR TITLE
Update Lambda@Edge description to indicate Node runtime restriction

### DIFF
--- a/doc_source/lambda-edge.md
+++ b/doc_source/lambda-edge.md
@@ -1,6 +1,6 @@
 # Lambda@Edge<a name="lambda-edge"></a>
 
-Lambda@Edge lets you run Lambda functions to customize content that CloudFront delivers, executing the functions in AWS locations closer to the viewer\. The functions run in response to CloudFront events, without provisioning or managing servers\. You can use Lambda functions to change CloudFront requests and responses at the following points:
+Lambda@Edge lets you run Node.js Lambda functions to customize content that CloudFront delivers, executing the functions in AWS locations closer to the viewer\. The functions run in response to CloudFront events, without provisioning or managing servers\. You can use Lambda functions to change CloudFront requests and responses at the following points:
 + After CloudFront receives a request from a viewer \(viewer request\)
 + Before CloudFront forwards the request to the origin \(origin request\)
 + After CloudFront receives the response from the origin \(origin response\)


### PR DESCRIPTION
Indicates in the blurb that Lambda@Edge only supports the Node runtime, which lets users know of this restriction up front instead of needing to either hit an error message after trying another run time or viewing the restrictions doc which is hidden at the very end of the Lambda@Edge docs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
