### PR TITLE
remove backticks from go structured type sample

### DIFF
--- a/doc_source/go-programming-model-handler-types.md
+++ b/doc_source/go-programming-model-handler-types.md
@@ -52,7 +52,7 @@ import (
         "fmt"
         "github.com/aws/aws-lambda-go/lambda"
 )
- ``
+
 type MyEvent struct {
         Name string `json:"What is your name?"`
         Age int     `json:"How old are you?"`


### PR DESCRIPTION
*Description of changes:*

Noticed some ``` ` ``` in the middle of the sample. Compiler otherwise reports: `/Users/moffattb/yo.go|7 col 2| : expected declaration, found 'STRING' `

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
