### PR TITLE
Add RDS sample event

### DIFF
--- a/doc_source/eventsources.md
+++ b/doc_source/eventsources.md
@@ -11,6 +11,7 @@ JSON keys may vary in case between AWS event sources\.
 + [Scheduled Event Sample Event](#eventsources-scheduled-event)
 + [Amazon CloudWatch Logs Sample Event](#eventsources-cloudwatch-logs)
 + [Amazon SNS Sample Event](#eventsources-sns)
++ [Amazon RDS Sample Event](#eventsources-rds)
 + [Amazon DynamoDB Update Sample Event](#eventsources-ddb-update)
 + [Amazon Cognito Sync Trigger Sample Event](#eventsources-cognito-sync-trigger)
 + [Amazon Kinesis Data Streams Sample Event](#eventsources-kinesis-streams)
@@ -210,6 +211,35 @@ JSON keys may vary in case between AWS event sources\.
   ]
 }
 ```
+
+**Amazon RDS Sample Event**  <a name="eventsources-rds"></a>
+
+```
+{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": eventsubscriptionarn,
+      "EventSource": "aws:sns",
+      "Sns": {
+        "SignatureVersion": "1",
+        "Timestamp": "1970-01-01T00:00:00.000Z",
+        "Signature": "EXAMPLE",
+        "SigningCertUrl": "EXAMPLE",
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "Message": "{\"Event Source\":\"db-instance\",\"Event Time\":\"1970-01-01 00:00:00.000\",\"Identifier Link\":\"https://console.aws.amazon.com/rds/home?region=eu-west-1#dbinstance:id=dbinstanceid\",\"Source ID\":\"dbinstanceid\",\"Event ID\":\"http://docs.amazonwebservices.com/AmazonRDS/latest/UserGuide/USER_Events.html#RDS-EVENT-0002\",\"Event Message\":\"Finished DB Instance backup\"}",
+        "MessageAttributes": {},
+        "Type": "Notification",
+        "UnsubscribeUrl": "EXAMPLE",
+        "TopicArn": topicarn,
+        "Subject": "RDS Notification Message"
+      }
+    }
+  ]
+}
+```
+
+**Note** The first event send will not have (escaped) json in the `Message` key, but instead text like `This is a message to notify that RDS will attempt to send you event notifications of type db-instance to the topic topicarn`.
 
 **Amazon DynamoDB Update Sample Event**  <a name="eventsources-ddb-update"></a>
 


### PR DESCRIPTION
*Description of changes:*
RDS sends through SNS, but has its own format in the "Message" key. This adds an example of that. See https://twitter.com/ajaynairthinks/status/1089199985592160256 and https://github.com/awsdocs/amazon-rds-user-guide/pull/50 for context


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
