### PR TITLE
Fix output of OnlyErrors Go Lambda example

### DIFF
--- a/doc_source/go-programming-model-errors.md
+++ b/doc_source/go-programming-model-errors.md
@@ -25,8 +25,9 @@ Which will return:
 
 ```
 {
-            "errorMessage": "something went wrong!"
-            }
+  "errorMessage": "something went wrong!",
+  "errorType": "errorString"
+}
 ```
 
 ## Function Error Handling<a name="python-custom-errors"></a>


### PR DESCRIPTION
*Description of changes:*

Fix formatting and include all of the output for the OnlyErrors example for generating errors from Go Lambda functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
