### PR TITLE
Change method name from recordHandler to handleRequest for Java Sample

### DIFF
--- a/doc_source/with-kinesis-create-package.md
+++ b/doc_source/with-kinesis-create-package.md
@@ -48,7 +48,7 @@ import com.amazonaws.services.lambda.runtime.events.KinesisEvent.KinesisEventRec
 
 public class ProcessKinesisRecords implements RequestHandler<KinesisEvent, Void>{
   @Override
-  public Void recordHandler(KinesisEvent event, Context context)
+  public Void handleRequest(KinesisEvent event, Context context)
   {
     for(KinesisEventRecord rec : event.getRecords()) {
       System.out.println(new String(rec.getKinesis().getData().array()));


### PR DESCRIPTION
The method name for Java8 implementation must be handleRequest instead of recordHandler according to the source code https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/RequestHandler.java
Doing this fixes the compilation error for the sample code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
