### PR TITLE
Enable syntax highlighting in code.

### DIFF
--- a/doc_source/go-programming-model-context.md
+++ b/doc_source/go-programming-model-context.md
@@ -24,7 +24,7 @@ The Lambda context library provides the following global variables, methods, and
 
 Lambda functions have access to metadata about their environment and the invocation request\. This can be accessed at [Package context](https://golang.org/pkg/context/)\. Should your handler include `context.Context` as a parameter, Lambda will insert information about your function into the context's `Value` property\. Note that you need to import the `lambdacontext` library to access the contents of the `context.Context` object\.
 
-```
+```go
 package main
  
 import (
@@ -50,7 +50,7 @@ In the example above, `lc` is the variable used to consume the information that 
 
 The following example introduces how to use the context object to monitor how long it takes to execute your Lambda function\. This allows you to analyze performance expectations and adjust your function code accordingly, if needed\. 
 
-```
+```go
 package main
 
 import (


### PR DESCRIPTION
Possibly breaks docs on docs.aws.amazon.com.
Needs to be changed for all code snippets.

*Issue #, if available:*

*Description of changes:* Enables syntax highlighting for go code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
