### PR TITLE
Use built-in SAM Events

### DIFF
--- a/sample-apps/error-processor/error-processor.yaml
+++ b/sample-apps/error-processor/error-processor.yaml
@@ -38,6 +38,12 @@ Resources:
         Variables:
           bucket: !Ref bucket
       Tracing: Active
+      Events:
+        LogsSubscription:
+          Type: CloudWatchLogs
+          Properties:
+            LogGroupName: !Join [ "/", [ "/aws/lambda", !Ref randomerror ] ]
+            FilterPattern: ERROR
   randomerror:
     Type: AWS::Serverless::Function
     Properties:
@@ -88,18 +94,3 @@ Resources:
     Properties:
       ServiceToken: !GetAtt primer.Arn
       FunctionName: !Ref randomerror
-  subscription:
-    Type: AWS::Logs::SubscriptionFilter
-    DependsOn: cloudwatchlogspermission
-    Properties:
-      LogGroupName: !Join [ "/", [ "/aws/lambda", !Ref randomerror ] ]
-      FilterPattern: ERROR
-      DestinationArn: !GetAtt processor.Arn
-  cloudwatchlogspermission:
-    Type: AWS::Lambda::Permission
-    DependsOn: primerinvoke
-    Properties:
-      FunctionName: !GetAtt processor.Arn
-      Action: lambda:InvokeFunction
-      Principal: !Join [ ".", [ "logs", !Ref "AWS::Region", "amazonaws.com" ] ]
-      SourceAccount: !Ref AWS::AccountId


### PR DESCRIPTION
As for the official documentation: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cloudwatchlogs

*Description of changes:*

I have replaced the raw CloudFormation resources with a proper SAM event defined on the processor function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
