### PR TITLE
Correcting case of eventSourceArn property

### DIFF
--- a/doc_source/with-sqs.md
+++ b/doc_source/with-sqs.md
@@ -22,7 +22,7 @@ Lambda polls the queue and invokes your function [synchronously](invocation-opti
             "messageAttributes": {},
             "md5OfBody": "098f6bcd4621d373cade4e832627b4f6",
             "eventSource": "aws:sqs",
-            "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+            "eventSourceArn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
             "awsRegion": "us-east-2"
         },
         {
@@ -38,7 +38,7 @@ Lambda polls the queue and invokes your function [synchronously](invocation-opti
             "messageAttributes": {},
             "md5OfBody": "098f6bcd4621d373cade4e832627b4f6",
             "eventSource": "aws:sqs",
-            "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+            "eventSourceArn": "arn:aws:sqs:us-east-2:123456789012:my-queue",
             "awsRegion": "us-east-2"
         }
     ]


### PR DESCRIPTION
This corrects the example to use the right casing... otherwise for example with the Java SDK you will get ```Unrecognized field "eventSourceARN"``` when trying to mock it

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
