### PR TITLE
Use runtimeClasspath instead of compileClasspath

### DIFF
--- a/doc_source/create-deployment-pkg-zip-java.md
+++ b/doc_source/create-deployment-pkg-zip-java.md
@@ -59,7 +59,7 @@ After you build the project, the resulting \.zip file \(that is, your deployment
        from compileJava
        from processResources              
        into('lib') {
-           from configurations.compileClasspath
+           from configurations.runtimeClasspath
        }           
    }
    
@@ -122,7 +122,7 @@ task buildZip(type: Zip) {
     from compileJava
     from processResources              
     into('lib') {
-        from configurations.compileClasspath
+        from configurations.runtimeClasspath
     }           
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Runtime classpath contains elements of the implementation, as well as runtime only elements.

This is important i.e. for multi-module projects with cross-module dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
