### PR TITLE
Corrected spelling of documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lambda User Guide and API operations and how it integrates with other AWS Service
 
-Start  with documentaion [index](/doc_source/index.md)
+Start  with documentation [index](/doc_source/index.md)
 
 ## License Summary
 


### PR DESCRIPTION
The word 'documentation' was missing a 't'.

*Issue #, if available:*
None.

*Description of changes:*
Spelling error corrected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
