### PR TITLE
Link to Amazon Step Functions

### DIFF
--- a/doc_source/lambda-services.md
+++ b/doc_source/lambda-services.md
@@ -62,7 +62,7 @@ Other services invoke your function directly\. You grant the other service permi
 + [Amazon API Gateway](with-on-demand-https.md)
 + [Amazon CloudFront \(Lambda@Edge\)](lambda-edge.md)
 + [Amazon Kinesis Data Firehose](services-kinesisfirehose.md)
-+ [Amazon Step Functions](https://github.com/awsdocs/aws-step-functions-developer-guide/blob/master/doc_source/connect-lambda.md)
++ [AWS Step Functions](https://github.com/awsdocs/aws-step-functions-developer-guide/blob/master/doc_source/connect-lambda.md)
 
 For asynchronous invocation, Lambda queues the event before passing it to your function\. The other service gets a success response as soon as the event is queued and isn't aware of what happens afterwards\. If an error occurs, Lambda handles [retries](retries-on-errors.md), and can send failed events to a [dead\-letter queue](invocation-async.md#dlq) that you configure\.
 

--- a/doc_source/lambda-services.md
+++ b/doc_source/lambda-services.md
@@ -62,6 +62,7 @@ Other services invoke your function directly\. You grant the other service permi
 + [Amazon API Gateway](with-on-demand-https.md)
 + [Amazon CloudFront \(Lambda@Edge\)](lambda-edge.md)
 + [Amazon Kinesis Data Firehose](services-kinesisfirehose.md)
++ [Amazon Step Functions](https://github.com/awsdocs/aws-step-functions-developer-guide/blob/master/doc_source/connect-lambda.md)
 
 For asynchronous invocation, Lambda queues the event before passing it to your function\. The other service gets a success response as soon as the event is queued and isn't aware of what happens afterwards\. If an error occurs, Lambda handles [retries](retries-on-errors.md), and can send failed events to a [dead\-letter queue](invocation-async.md#dlq) that you configure\.
 


### PR DESCRIPTION
Link Step Functions to list of services that can invoke Amazon Lambda.

*Description of changes:*

Add a link to AWS Step Functions in the list of possible Lambda triggers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
