### PR TITLE
Update info about lambda's default VPC

### DIFF
--- a/doc_source/configuration-vpc.md
+++ b/doc_source/configuration-vpc.md
@@ -69,7 +69,7 @@ $ aws lambda update-function-configuration --function-name my-function \
 
 ## Internet and Service Access for VPC\-Connected Functions<a name="vpc-internet"></a>
 
-By default, Lambda runs your functions in a secure VPC with access to AWS services and the internet\. When you connect a function to a VPC in your account, it does not have access to the internet unless your VPC provides access\.
+By default, Lambda runs your functions in a secure VPC with access to AWS services and the internet\. This VPC is owned by AWS and is different from the default VPC in your AWS account\. When you connect a function to a VPC in your account, it does not have access to the internet unless your VPC provides access\.
 
 **Note**  
 Several services offer [VPC endpoints](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html)\. You can use VPC endpoints to connect to AWS services from within a VPC without internet access\.


### PR DESCRIPTION
*Description of changes:*
Referring to https://stackoverflow.com/questions/48027737/what-are-the-default-aws-lambda-vpc-settings and some resources online, I came to understand that by default, lambda is created with a VPC which is not owned by the customer account. I sometimes confuse this default lambda VPC with the default VPC provided with an AWS account. 
I believe mentioning this explicitly in this section might be helpful to others. Please feel free to suggest an alternate place for this info

*Issue #, if available:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
