### PR TITLE
Update configuration-aliases.md

### DIFF
--- a/doc_source/configuration-aliases.md
+++ b/doc_source/configuration-aliases.md
@@ -26,7 +26,7 @@ $ aws lambda create-alias --function-name my-function --function-version version
 To change an alias to point a new version of the function, use the `update-alias` command\.
 
 ```
-$ aws lambda update-alias --function-name my-function --function-version version number 
+$ aws lambda update-alias --function-name my-function --function-version version number --name alias name
 ```
 
  The AWS CLI commands in the preceding steps correspond to the following AWS Lambda APIs: 


### PR DESCRIPTION
Update command requires --name argument to specify which alias is to be updated. Error is "aws: error: argument --name is required"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
