### PR TITLE
Adding warning regarding PC and Lambda@Edge

### DIFF
--- a/doc_source/configuration-concurrency.md
+++ b/doc_source/configuration-concurrency.md
@@ -45,6 +45,8 @@ Setting per\-function concurrency can impact the concurrency pool that is availa
 
 To manage provisioned concurrency settings for a version or alias, use the Lambda console\.
 
+**Note:** Provisioned Concurrency is not supported with [Lambda@Edge](https://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html)
+
 **To reserve concurrency for an alias**
 
 1. Open the Lambda console [Functions page](https://console.aws.amazon.com/lambda/home#/functions)\.


### PR DESCRIPTION
Per the announce doc (https://aws.amazon.com/blogs/aws/new-provisioned-concurrency-for-lambda-functions/) Provisioned Concurrency isn't supported with Lambda@Edge, however this isn't currently mentioned anywhere in the docs. Adding it here as it seems to be the most relevant section of the docs.

*Issue #, if available:*

*Description of changes:*
Added a one line warning in the section describing how to enable provisioned concurrency that it is not currently supported with Lambda@Edge

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
