### PR TITLE
Fix arguments to match current binary

### DIFF
--- a/doc_source/lambda-go-how-to-create-deployment-package.md
+++ b/doc_source/lambda-go-how-to-create-deployment-package.md
@@ -42,7 +42,7 @@ In cmd\.exe, run the following:
 ```
 set GOOS=linux
 go build -o main main.go
-%USERPROFILE%\Go\bin\build-lambda-zip.exe -o main.zip main
+%USERPROFILE%\Go\bin\build-lambda-zip.exe --output main.zip main
 ```
 
 In Powershell, run the following:
@@ -50,5 +50,5 @@ In Powershell, run the following:
 ```
 $env:GOOS = "linux"
 go build -o main main.go
-~\Go\Bin\build-lambda-zip.exe -o main.zip main
+~\Go\Bin\build-lambda-zip.exe --output main.zip main
 ```


### PR DESCRIPTION
`-o` does not seem to be a valid argument in the current binary

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
