### PR TITLE
Fix handler function name in Java example for event type of `InputStream` and `OutputStream`

### DIFF
--- a/doc_source/java-handler-io-type-stream.md
+++ b/doc_source/java-handler-io-type-stream.md
@@ -9,16 +9,17 @@ The following is a Lambda function example that implements the handler that uses
 ```
 package example;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.amazonaws.services.lambda.runtime.Context; 
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 
-public class Hello implements RequestStreamHandler{
-    public void handler(InputStream inputStream, OutputStream outputStream, Context context) throws IOException {
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class Hello implements RequestStreamHandler {
+    public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) throws IOException {
         int letter;
-        while((letter = inputStream.read()) != -1)
-        {
+        while ((letter = inputStream.read()) != -1) {
             outputStream.write(Character.toUpperCase(letter));
         }
     }
@@ -27,6 +28,7 @@ public class Hello implements RequestStreamHandler{
 
 **Dependencies**
 + `aws-lambda-java-core`
-+ **Handler** – `example.Hello::handler`
+
+**Handler** - `example.Hello::handleRequest`
 
 The event received processed by the function must be valid JSON but the output stream type is not restricted\. Any bytes are supported\.


### PR DESCRIPTION
*Issue #, if available:*

The handler function/method name defined in the example class `Hello` does not match the signature of the method defined in the implemented interface `com.amazonaws.services.lambda.runtime.RequestStreamHandler`.

*Description of changes:*

This commit:
  -  changes the name of the handler function/method defined in class `Hello` to match the signature of the method in interface `com.amazonaws.services.lambda.runtime.RequestStreamHandler` (https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/RequestStreamHandler.java).
  - adds a missing `import` statement for `java.io.IOException`
  - fixes a minor formatting issue with the Handler sub-header

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
