### PR TITLE
Fix Handler name in Handler section

### DIFF
--- a/doc_source/java-handler-stream.md
+++ b/doc_source/java-handler-stream.md
@@ -19,7 +19,7 @@ import java.io.OutputStream;
 public class Hello implements RequestStreamHandler {
     public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context) throws IOException {
         int letter;
-        while((letter = inputStream.read()) != -1) {
+        while ((letter = inputStream.read()) != -1) {
             outputStream.write(Character.toUpperCase(letter));
         }
     }
@@ -29,6 +29,6 @@ public class Hello implements RequestStreamHandler {
 **Dependencies**
 + `aws-lambda-java-core`
 
-**Handler** – `example.Hello::handler`
+**Handler** – `example.Hello`
 
-The event received processed by the function must be valid JSON but the output stream type is not restricted\. Any bytes are supported\.
+When you create the Lambda function, specify `example.Hello` \(*package*\.*class*\) as the handler value\.

--- a/doc_source/java-handler-stream.md
+++ b/doc_source/java-handler-stream.md
@@ -32,3 +32,5 @@ public class Hello implements RequestStreamHandler {
 **Handler** – `example.Hello`
 
 When you create the Lambda function, specify `example.Hello` \(*package*\.*class*\) as the handler value\.
+
+The format of the data in the input stream that's received and processed by the function must be valid JSON but the format of the data in the output stream is not restricted\. Any bytes are supported\.


### PR DESCRIPTION
*Issue #, if available:*
(N/A)

*Description of changes:*
This commit:
- changes the handler name in the **Handler** section to make it match what's in the code
- removes a statement that does not make sense in the context of this particular kind of handlers which process byte streams, instead of events.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
