### PR TITLE
Clarify that cURL will block waiting for an event

### DIFF
--- a/doc_source/runtimes-walkthrough.md
+++ b/doc_source/runtimes-walkthrough.md
@@ -52,8 +52,10 @@ source $LAMBDA_TASK_ROOT/"$(echo $_HANDLER | cut -d. -f1).sh"
 while true
 do
   HEADERS="$(mktemp)"
-  # Get an event
+  # Get an event. The HTTP request will block until one is received
   EVENT_DATA=$(curl -sS -LD "$HEADERS" -X GET "http://${AWS_LAMBDA_RUNTIME_API}/2018-06-01/runtime/invocation/next")
+  
+  # Extract request ID by scraping response headers received above
   REQUEST_ID=$(grep -Fi Lambda-Runtime-Aws-Request-Id "$HEADERS" | tr -d '[:space:]' | cut -d: -f2)
 
   # Execute the handler function from the script


### PR DESCRIPTION
Reading the docs the first time it was not immediately clear that this was supposed to happen.