### PR TITLE
Stream Property doesn't exist in Event property

### DIFF
--- a/doc_source/with-kinesis-example-use-app-spec.md
+++ b/doc_source/with-kinesis-example-use-app-spec.md
@@ -18,7 +18,7 @@ Resources:
       Timeout: 10
       Tracing: Active
       Events:
-        Stream:
+        Properties:
           Type: Kinesis
           Properties:
             Stream: !GetAtt stream.Arn
@@ -56,7 +56,7 @@ Resources:
       Timeout: 10
       Tracing: Active
       Events:
-        Stream:
+        Properties:
           Type: Kinesis
           Properties:
             Stream: !GetAtt streamConsumer.ConsumerARN


### PR DESCRIPTION
This samples weren't working: There is no Property named Stream in the Events definition. According to https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-eventsource.html the code should look like:

Resources:
  LambdaFunction:
    Type: AWS::Serverless::Function
    Properties:
      Handler: index.handler
      Runtime: nodejs12.x
      Timeout: 10
      Tracing: Active
      Events:
        Properties: <------- This is the difference
          Type: Kinesis
          Properties:
            Stream: !GetAtt stream.Arn
            BatchSize: 100
            StartingPosition: LATEST

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
