### PR TITLE
Updated put-method-response and put-integration-response

### DIFF
--- a/doc_source/services-apigateway-tutorial.md
+++ b/doc_source/services-apigateway-tutorial.md
@@ -325,7 +325,7 @@ Set `content-type` of the `POST` method response and integration response to JSO
   ```
   $ aws apigateway put-method-response --rest-api-id $API \
   --resource-id $RESOURCE --http-method POST \
-  --status-code 200 --response-models application/json=Empty
+  --status-code 200 --response-models "{\"application/json"\":""\"Empty"\"}"""
   {
       "statusCode": "200",
       "responseModels": {
@@ -338,7 +338,7 @@ Set `content-type` of the `POST` method response and integration response to JSO
   ```
   $ aws apigateway put-integration-response --rest-api-id $API \
   --resource-id $RESOURCE --http-method POST \
-  --status-code 200 --response-templates application/json=""
+  --status-code 200 --response-templates "{\"application/json"\":""\"\"}""
   {
       "statusCode": "200",
       "responseTemplates": {


### PR DESCRIPTION
aws apigateway put-method-response --rest-api-id $API \
--resource-id $RESOURCE --http-method POST \
--status-code 200 --response-models application/json=Empty 
 and 

aws apigateway put-integration-response --rest-api-id $API \
--resource-id $RESOURCE --http-method POST \
--status-code 200 --response-templates application/json=""

were generating "Error parsing parameter '--response-templates': Expected: '=', received: '/' for input:"

this edit will fix this issue, so new comers wont face problem while following the tuts

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
