### PR TITLE
The correct env var for Ruby Lib is RUBYLIB

### DIFF
--- a/doc_source/configuration-layers.md
+++ b/doc_source/configuration-layers.md
@@ -171,7 +171,7 @@ To include libraries in a layer, place them in one of the folders supported by y
   jackson.zip
   └ java/lib/jackson-core-2.2.3.jar
   ```
-+ **Ruby** – `ruby/gems/2.5.0` \(`GEM_PATH`\), `ruby/lib` \(`RUBY_LIB`\)  
++ **Ruby** – `ruby/gems/2.5.0` \(`GEM_PATH`\), `ruby/lib` \(`RUBYLIB`\)  
 **Example JSON**  
 
   ```


### PR DESCRIPTION
Not `RUBY_LIB`. Which is easy to mistake because the other env vars, like `GEM_PATH`, would make you think that's the correct name. See the [Docker](https://github.com/lambci/docker-lambda/blob/master/ruby2.5/build/Dockerfile) file as a reference.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
