### PR TITLE
Fix title of the checked web site

### DIFF
--- a/doc_source/services-cloudwatchevents-tutorial.md
+++ b/doc_source/services-cloudwatchevents-tutorial.md
@@ -33,7 +33,7 @@ This tutorial assumes that you have some knowledge of basic Lambda operations an
    + **Enabled** – True \(checked\)\.
    + **Environment variables**
      + **site** – **https://docs\.aws\.amazon\.com/lambda/latest/dg/welcome\.html**\.
-     + **expected** – **What Is AWS Lambda?**\.
+     + **expected** – **What is AWS Lambda?**\.
 
 1. Choose **Create function**\.
 


### PR DESCRIPTION
Right now lambda checks for "What Is AWS Lambda?" title on the page. However, the title of the page is "What is AWS Lambda?"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
