### PR TITLE
Fix installation command for sharp

### DIFF
--- a/doc_source/with-s3-example.md
+++ b/doc_source/with-s3-example.md
@@ -168,13 +168,13 @@ The deployment package is a \.zip file containing your Lambda function code and 
 1. Install the Sharp library with npm\. For Linux, use the following command\.
 
    ```
-   lambda-s3$ npm install sharp
+   lambda-s3$ npm install --arch=x64 --platform=linux --target=12.13.0  sharp
    ```
 
    For macOS, use the following command\.
 
    ```
-   lambda-s3$ npm install --arch=x64 --platform=linux --target=12.13.0  sharp
+   lambda-s3$ npm install sharp
    ```
 
    After you complete this step, you will have the following folder structure:


### PR DESCRIPTION
Commands for installing sharp on linux and macOS were swapped in the docs. This PR fixes it.