### PR TITLE
Changed "Events" checkbox label to match the S3 UI

### DIFF
--- a/doc_source/with-s3-example.md
+++ b/doc_source/with-s3-example.md
@@ -304,7 +304,7 @@ This procedure configures the bucket to invoke your function every time an objec
 
 1. Under **Events**, configure a notification with the following settings\.
    + **Name** – **lambda\-trigger**\.
-   + **Events** – **ObjectCreate \(All\)**\.
+   + **Events** – **All object create events**\.
    + **Send to** – **Lambda function**\.
    + **Lambda** – **CreateThumbnail**\.
 


### PR DESCRIPTION
*Issue #, if available: N/A*

*Description of changes:  changed the label for the checkbox to select in the "Events" group, from "ObjectCreate (All)" to the correct "All object create events", because the latter is what appears in the UI. *


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
