### PR TITLE
Update random-error custom resource wait time

### DIFF
--- a/sample-apps/error-processor/template.yml
+++ b/sample-apps/error-processor/template.yml
@@ -84,7 +84,7 @@ Resources:
             await Promise.all([
               lambda.invoke({ FunctionName: functionName2 }).promise(),
               lambda.invoke({ FunctionName: functionName3 }).promise(),
-              new Promise(resolve => setTimeout(resolve, 10000))
+              new Promise(resolve => setTimeout(resolve, 15000))
             ])
             // Set log retention on all log groups
             await Promise.all([


### PR DESCRIPTION
I saw a transient deployment error due to log group creation taking longer than usual. Increasing wait time before continuing to log group creation to 15s.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
