### PR TITLE
Lambda is given additional permissions than required

### DIFF
--- a/doc_source/with-s3-example.md
+++ b/doc_source/with-s3-example.md
@@ -36,6 +36,62 @@ Install npm to manage the function's dependencies\.
 
 The tutorial uses AWS CLI commands to create and invoke the Lambda function\. Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) 
 
+## Create buckets and upload a sample object<a name="with-s3-example-prepare-create-buckets"></a>
+
+Follow the steps to create buckets and upload an object\.
+
+1. Open the [Amazon S3 console](https://console.aws.amazon.com/s3)\.
+
+1. Create two buckets\. The target bucket name must be *source* followed by **\-resized**, where *source* is the name of the bucket you want to use for the source\. For example, `mybucket` and `mybucket-resized`\.
+
+1. In the source bucket, upload a \.jpg object, `HappyFace.jpg`\. 
+
+   When you invoke the Lambda function manually before you connect to Amazon S3, you pass sample event data to the function that specifies the source bucket and `HappyFace.jpg` as the newly created object so you need to create this sample object first\.
+
+## Create the IAM Policy<a name="with-s3-and-cloudwatch-logs-permissions"></a>
+
+Create an IAM policy that defines the permissions for the Lambda. The required permissions are to get the object from the source S3 bucket, put the resized object to the target S3 bucket and permissions around the CloudWatch Logs\.
+
+**To create an IAM Policy**
+
+1. Open the [policies page](https://console.aws.amazon.com/iam/home#/policies) in the IAM Console\.
+
+1. Choose **Create policy**\.
+
+1. Under the JSON tab, copy the below JSON. Make sure the source and target bucket names match with the bucket names created in the previous step\.
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:PutLogEvents",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": "arn:aws:s3:::mybucket/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::mybucket-resized/*"
+        }
+    ]
+}
+```
+1. Click on `Review policy`, specify the policy name as`AWSLambdaS3Policy` and finally create the policy\.
+
 ## Create the execution role<a name="with-s3-create-execution-role"></a>
 
 Create the [execution role](lambda-intro-execution-role.md) that gives your function permission to access AWS resources\.
@@ -48,22 +104,10 @@ Create the [execution role](lambda-intro-execution-role.md) that gives your func
 
 1. Create a role with the following properties\.
    + **Trusted entity** – **AWS Lambda**\.
-   + **Permissions** – **AWSLambdaExecute**\.
+   + **Permissions** – **AWSLambdaS3Policy**\.
    + **Role name** – **lambda\-s3\-role**\.
 
-The **AWSLambdaExecute** policy has the permissions that the function needs to manage objects in Amazon S3 and write logs to CloudWatch Logs\.
-
-## Create buckets and upload a sample object<a name="with-s3-example-prepare-create-buckets"></a>
-
-Follow the steps to create buckets and upload an object\.
-
-1. Open the [Amazon S3 console](https://console.aws.amazon.com/s3)\.
-
-1. Create two buckets\. The target bucket name must be *source* followed by **\-resized**, where *source* is the name of the bucket you want to use for the source\. For example, `mybucket` and `mybucket-resized`\.
-
-1. In the source bucket, upload a \.jpg object, `HappyFace.jpg`\. 
-
-   When you invoke the Lambda function manually before you connect to Amazon S3, you pass sample event data to the function that specifies the source bucket and `HappyFace.jpg` as the newly created object so you need to create this sample object first\.
+The **AWSLambdaS3Policy** has the permissions that the function needs to manage objects in Amazon S3 and write logs to CloudWatch Logs\.
 
 ## Create the function<a name="with-s3-example-create-function"></a>
 


### PR DESCRIPTION
Lambda is given the permissions via the AWSLambdaExecute Policy which gives access to all the S3 buckets in the current AWS Account. The Lambda simply needs s3:GetObject permissions on the source S3 bucket , s3:PutObject permissions on the target S3 bucket and write permissions around the CloudWatch Logs.

What is being done in this Lambda is a common scenario and I have given this page as a reference to a lot many and they might be blindly following the documentation to give the unnecessary permissions to the Lambda. So, the changes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
