### PR TITLE
change blank-go link from master branch to main

### DIFF
--- a/doc_source/lambda-golang.md
+++ b/doc_source/lambda-golang.md
@@ -16,7 +16,7 @@ AWS Lambda provides the following libraries for Go:
 
 **Note**  
 To get started with application development in your local environment, deploy one of the sample applications available in this guide's GitHub repository\.  
-[blank\-go](https://github.com/awsdocs/aws-lambda-developer-guide/tree/master/sample-apps/blank-go) – A Go function that shows the use of Lambda's Go libraries, logging, environment variables, and the AWS SDK\.
+[blank\-go](https://github.com/awsdocs/aws-lambda-developer-guide/tree/main/sample-apps/blank-go) – A Go function that shows the use of Lambda's Go libraries, logging, environment variables, and the AWS SDK\.
 
 **Topics**
 + [AWS Lambda deployment package in Go](golang-package.md)


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Since the github repo has switched default branch from 'master' to 'main', request to update any old links including this one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.