### PR TITLE
fix golang tracing

### DIFF
--- a/doc_source/golang-tracing.md
+++ b/doc_source/golang-tracing.md
@@ -41,6 +41,12 @@ To instrument AWS SDK clients, pass the client to the `xray.AWS()` method\.
     xray.AWS(s3.Client)
 ```
 
+Then you can trace your calls by using the `WithContext` version of the method\.
+
+```
+    svc.ListBucketsWithContext(ctx, &s3.ListBucketsInput{})
+```
+
 The following example shows a trace with 2 segments\. Both are named **my\-function**, but one is type `AWS::Lambda` and the other is `AWS::Lambda::Function`\. The function segment is expanded to show its subsegments\.
 
 ![\[Image NOT FOUND\]](http://docs.aws.amazon.com/lambda/latest/dg/images/nodejs-xray-timeline.png)


### PR DESCRIPTION
added example with 'WithContext' method, as a user it was not clear that in this case
the 'WithContext' method is needed

*Issue #, if available:*

*Description of changes:*
I have added an extra step to the golang tracing example, as a user it was not clear that I needed to use the `WithContext` method in this case.
The description jump right to show the traces and tricked me to believe that I can use the "conventional" method call.

As far as I know some tracers (at least for go) don't need to use any different method, I thought it was good to add a little bit more description.
Thanks =)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
