### PR TITLE
Add notice for doesn't support to use cross account ECR image when creating Lambda function (lambda-images.md)

### DIFF
--- a/doc_source/lambda-images.md
+++ b/doc_source/lambda-images.md
@@ -8,6 +8,8 @@ Additionally, AWS provides a runtime interface emulator for you to test your fun
 
 There is no additional charge for packaging and deploying functions as container images\. When a function deployed as a container image is invoked, you pay for invocation requests and execution duration\. You do incur charges related to storing your container images in Amazon ECR\. For more information, see [Amazon ECR pricing](http://aws.amazon.com/ecr/pricing/)\. 
 
+**Note**: Using the container image currently only support for the image from Amazon ECR in the same AWS account.
+
 **Topics**
 + [Creating Lambda container images](images-create.md)
 + [Testing Lambda container images locally](images-test.md)


### PR DESCRIPTION
Since Dec 2020, Lambda start to support Container Image 

- [AWS News Blog, New for AWS Lambda – Container Image Support](https://aws.amazon.com/tw/blogs/aws/new-for-aws-lambda-container-image-support/)

When creating Lambda function, it doesn't support to use cross account ECR image. The  URI of a container image in the Amazon ECR registry should be the same account otherwise you will see:
```
An error occurred (InvalidParameterValueException) when calling the CreateFunction operation: Image repository must be in the same account as the caller
```

*Issue #, if available:*

#### How to reproduce:

I can reproduce this issue when using different AWS account: 

- `111111111111` is my own testing AWS account
- `222222222222` is my production AWS account

1. Pushed image `node:11.6-alpine` to my ECR repositories (in `111111111111` and `222222222222`)
2. Create Lambda function in account `111111111111`

It looks good if using the ECR image from same account:

```bash
$ aws lambda create-function \
>     --function-name my-function \
>     --code "ImageUri=111111111111.dkr.ecr.ap-northeast-1.amazonaws.com/node:11.6-alpine" \
>     --package-type Image \
>     --role arn:aws:iam::111111111111:role/service-role/testing-role-xf9nzdjv \
>     --region ap-northeast-1

{
    "FunctionName": "my-function",
    "FunctionArn": "arn:aws:lambda:ap-northeast-1:111111111111:function:my-function",
    "Role": "arn:aws:iam::111111111111:role/service-role/testing-role-xf9nzdjv",
    "CodeSize": 0,
    "Description": "",
    "Timeout": 3,
    "MemorySize": 128,
    "LastModified": "2021-01-05T09:34:53.976+0000",
    "CodeSha256": "..........",
    "Version": "$LATEST",
    "TracingConfig": {
        "Mode": "PassThrough"
    },
    ....
    "StateReason": "The function is being created.",
    "StateReasonCode": "Creating",
    "PackageType": "Image"
}
```

However, if the image is from account `222222222222`, the creation will fail and able to see the error: 

```bash
$ aws lambda create-function \
>     --function-name my-function-2 \
>     --code "ImageUri=222222222222.dkr.ecr.us-west-2.amazonaws.com/node:11.6-alpine" \
>     --package-type Image \
>     --role arn:aws:iam::111111111111:role/service-role/testing-role-xf9nzdjv \
>     --region ap-northeast-1

An error occurred (InvalidParameterValueException) when calling the CreateFunction operation: Image repository must be in the same account as the caller
```


*Description of changes:*

As I did not see any wording is mentioning about this constraint, it might cause some issue if having cross account use case. The workaround might be pushing image to the same account, but I still would like to add a notice to current documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
