### PR TITLE
Rogue .

### DIFF
--- a/doc_source/getting-started-create-function.md
+++ b/doc_source/getting-started-create-function.md
@@ -199,7 +199,7 @@ In the following commands, replace `123456789012` with your AWS account ID\.
    1. Test your Lambda function\. From your project directory, run a `curl` command to invoke your function:
 
       ```
-      curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'.
+      curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'
       ```
 
 ### Upload the image to the Amazon ECR repository<a name="gettingstarted-create-upload"></a>


### PR DESCRIPTION
There was an extra . at the end of the curl command which caused curl to try to do a second call after the first to localhost.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
