### PR TITLE
Fix assertEquals arguments in Java Events sample

### DIFF
--- a/sample-apps/java-events/src/test/java/example/InvokeTest.java
+++ b/sample-apps/java-events/src/test/java/example/InvokeTest.java
@@ -27,7 +27,7 @@ class InvokeTest {
     String requestId = context.getAwsRequestId();
     Handler handler = new Handler();
     APIGatewayV2ProxyResponseEvent result = handler.handleRequest(event, context);
-    assertEquals(result.getStatusCode(),200);
+    assertEquals(200, result.getStatusCode());
   }
 
 }


### PR DESCRIPTION
Swap arguments to reflect positions for expected and actual with assertEquals.