### PR TITLE
Fix to VPC endpoint policy example

### DIFF
--- a/doc_source/configuration-vpc-endpoints.md
+++ b/doc_source/configuration-vpc-endpoints.md
@@ -80,7 +80,9 @@ The following is an example of an endpoint policy for Lambda\. When attached to 
 {
    "Statement":[
       {
-         "Principal": "arn:aws:iam::123412341234:user/MyUser",
+         "Principal": {
+            "AWS": "arn:aws:iam::123412341234:user/MyUser",
+         }
          "Effect":"Allow",
          "Action":[
             "lambda:InvokeFunction"


### PR DESCRIPTION
Fixed the VPC endpoint policy example to show a correct version of how Principal should be used per the docs[1]. The previous example would return an error if you attempted to use a Principal in that manner.

[1] https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-accounts

*Issue #, if available:* N/A

*Description of changes:* Fixed an error in the VPC endpoint docs that would result in an error if someone attempted to follow them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
