### PR TITLE
Update python-package.md

### DIFF
--- a/doc_source/python-package.md
+++ b/doc_source/python-package.md
@@ -62,6 +62,9 @@ To create or update a function with the Lambda API, create a deployment package 
    }
    ```
 
+**Note**
+In order for your Python modules can be imported at runtime, ensure the files in the zip produced are globally readable (o+r) and any directories are globally readable (o+x).
+
 ## Updating a function with additional dependencies<a name="python-package-dependencies"></a>
 
 If your Lambda function depends on libraries other than the AWS SDK for Python \(Boto3\), install them to a local directory with [pip](https://pypi.org/project/pip/), and include them in your deployment package\.


### PR DESCRIPTION
I spent many hours tracking down why my Python modules were not importable. When I renamed the package folder in the console from A to B and back from B to A the issue resolved and this led me to the discovery that files and directories must be globally readable for the Lambda to run despite everything looking perfectly OK in the console. I think it is important to fix this flaw or let people know about it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
