### PR TITLE
Fix configuration-codesigning.md

### DIFF
--- a/doc_source/configuration-codesigning.md
+++ b/doc_source/configuration-codesigning.md
@@ -145,7 +145,8 @@ The following example policy statement grants permission to create, update, and 
           "lambda:CreateCodeSigningConfig",
           "lambda:UpdateCodeSigningConfig",
           "lambda:GetCodeSigningConfig"
-        ]
+        ],
+      "Resource": "*"
     }
   ]
 }
@@ -168,7 +169,7 @@ The following example policy statement grants permission to create a function\. 
       "Resource": "*",
       "Condition": {
           "StringEquals": {
-              "lambda:codeSigningConfig: {
+              "lambda:codeSigningConfig": 
                   “arn:aws:lambda:us-west-2:123456789012:code-signing-config:csc-0d4518bd353a0a7c6”
                }
           }


### PR DESCRIPTION
* Fix IAM policy formatting to add required Resource
* Fix condition StringEquals syntax

Syntax on both code snippets in Configure IAM policies section under the Code Signing Configuration documentation have syntax issues.

I want to note that the conditional in the documentation is either incorrect or misleading because the resource `lambda:codeSigningConfig` is not a supported condition key for `lambda:CreateFunction` as shown here https://docs.aws.amazon.com/service-authorization/latest/reference/list_awslambda.html#awslambda-actions-as-permissions

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
