### PR TITLE
'RequestId' to 'RequestID' in Golang Example

### DIFF
--- a/doc_source/services-apigateway-code.md
+++ b/doc_source/services-apigateway-code.md
@@ -125,7 +125,7 @@ import (
 )
 
 func handleRequest(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-    fmt.Printf("Processing request data for request %s.\n", request.RequestContext.RequestId)
+    fmt.Printf("Processing request data for request %s.\n", request.RequestContext.RequestID)
     fmt.Printf("Body size = %d.\n", len(request.Body))
 
     fmt.Println("Headers:")


### PR DESCRIPTION
In the Golang Lambda Handler for API Gateway, the RequestContext has no field as RequestId, so based on https://github.com/aws/aws-lambda-go/blob/v1.22.0/events/apigw.go#L32, field needs to be changed to 'RequestID'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
