### PR TITLE
Fix typo in adding RIE to the image example

### DIFF
--- a/doc_source/go-image.md
+++ b/doc_source/go-image.md
@@ -131,7 +131,7 @@ The steps are the same as described for a `provided.al2` base image, with one ad
    ```
    #!/bin/sh
    if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
-     exec /usr/local/bin/aws-lambda-rie "$@"
+     exec /usr/bin/aws-lambda-rie "$@"
    else
      exec "$@"
    fi


### PR DESCRIPTION
*Description of changes:*
There's inconsistency in the example of how to add RIE to the image.
Dockerfile `ADD` and `RUN` commands work with `/usr/bin/aws-lambda-rie`. But `entry.sh` script refers to `/usr/local/bin/aws-lambda-rie` that causes issues.

Alternatively, Dockerfile `ADD` and `RUN` commands can be updated to work with `/usr/local/bin/aws-lambda-rie`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
