### PR TITLE
Fixed reference to iotevents.amazonaws.com that should be iot.amazonaws.com

### DIFF
--- a/doc_source/services-iot.md
+++ b/doc_source/services-iot.md
@@ -24,7 +24,7 @@ You need to grant permission for the AWS IoT service to invoke your Lambda funct
 
 ```
 aws lambda add-permission --function-name my-function \
---statement-id iot-events --action "lambda:InvokeFunction" --principal iotevents.amazonaws.com
+--statement-id iot-events --action "lambda:InvokeFunction" --principal iot.amazonaws.com
 ```
 
 You should see the following output:


### PR DESCRIPTION
This code snippet references iotevents.amazonaws.com but should reference iot.amazonaws.com. This can be verified in the output JSON below the code that shows the service principal as “iot.amazonaws.com”.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
