### PR TITLE
Improve Go code example

### DIFF
--- a/doc_source/services-apigateway-code.md
+++ b/doc_source/services-apigateway-code.md
@@ -119,10 +119,18 @@ The following example processes messages from API Gateway, and logs information 
 **Example LambdaFunctionOverHttps\.go**  
 
 ```
+package main
+
 import (
-    "strings"
+    "context"
+    "fmt"
     "github.com/aws/aws-lambda-go/events"
+    runtime "github.com/aws/aws-lambda-go/lambda"
 )
+
+func main() {
+    runtime.Start(handleRequest)
+}
 
 func handleRequest(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
     fmt.Printf("Processing request data for request %s.\n", request.RequestContext.RequestID)
@@ -133,7 +141,7 @@ func handleRequest(ctx context.Context, request events.APIGatewayProxyRequest) (
         fmt.Printf("    %s: %s\n", key, value)
     }
 
-    return events.APIGatewayProxyResponse { Body: request.Body, StatusCode: 200 }, nil
+    return events.APIGatewayProxyResponse{Body: request.Body, StatusCode: 200}, nil
 }
 ```
 


### PR DESCRIPTION
Improvements to Go code example:

*Description of changes:*

 - Include `package main` and `func main() {... }` so that the example can be built and deployed directly.
 - Remove `strings` import as it is unused and blocks build.
 - Add `context`, `fmt` and `runtime` imports, as the existing code depends on these.
 - Remove extra spacing in `return` line, to match Go standard code format
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
