### PR TITLE
Update template.yml

### DIFF
--- a/sample-apps/s3-java/template.yml
+++ b/sample-apps/s3-java/template.yml
@@ -17,7 +17,7 @@ Resources:
       # Function's execution role
       Policies:
         - AWSLambdaBasicExecutionRole
-        - AWSLambdaReadOnlyAccess
+        - AWSLambda_ReadOnlyAccess
         - AWSXrayWriteOnlyAccess
         - AWSLambdaVPCAccessExecutionRole
         - AmazonS3FullAccess


### PR DESCRIPTION
After March 1, 2021, the AWS managed policies AWSLambdaReadOnlyAccess and AWSLambdaFullAccess will be deprecated and can no longer be attached to new IAM users.

Info: https://docs.aws.amazon.com/lambda/latest/dg/security_iam_troubleshoot.html

Without this, the 3-deploy.sh script will always fail.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
