### PR TITLE
clarify that context can be set by the caller

### DIFF
--- a/doc_source/nodejs-context.md
+++ b/doc_source/nodejs-context.md
@@ -27,7 +27,7 @@ When Lambda runs your function, it passes a context object to the [handler](node
   + `env.make`
   + `env.model`
   + `env.locale`
-  + `Custom` – Custom values that are set by the mobile application\. 
+  + `Custom` – Custom values that are set by the caller\. 
 + `callbackWaitsForEmptyEventLoop` – Set to false to send the response right away when the [callback](nodejs-handler.md#nodejs-handler-sync) runs, instead of waiting for the Node\.js event loop to be empty\. If this is false, any outstanding events continue to run during the next invocation\.
 
 The following example function logs context information and returns the location of the logs\.


### PR DESCRIPTION
there isn't anything specific to "mobile application" when context is set

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
