### PR TITLE
Update deprecated `Buffer()`

### DIFF
--- a/sample-apps/error-processor/processor/index.js
+++ b/sample-apps/error-processor/processor/index.js
@@ -83,7 +83,7 @@ var getTrace = function(context){
 
 exports.handler = function(event, context) {
     console.log("Event: " + JSON.stringify(event, null, 2))
-    var payload = new Buffer(event.awslogs.data, 'base64')
+    var payload = new Buffer.from(event.awslogs.data, 'base64')
     zlib.gunzip(payload, function(e, decodedEvent) {
         if (e) {
             context.fail(e)


### PR DESCRIPTION
... to use `Buffer.from()` instead
