### PR TITLE
Correct function-name argument in invocation call

### DIFF
--- a/doc_source/python-package-create.md
+++ b/doc_source/python-package-create.md
@@ -388,14 +388,14 @@ Invoke the Lambda function [synchronously](invocation-sync.md) using the event i
 #### [ macOS/Linux ]
 
   ```
-  aws lambda invoke --function-name requests-function --payload '{"key1": "value1", "key2": "value2", "key3": "value3"}' output.txt
+  aws lambda invoke --function-name my-sourcecode-function --payload '{"key1": "value1", "key2": "value2", "key3": "value3"}' output.txt
   ```
 
 ------
 #### [ Windows ]
 
   ```
-  aws lambda invoke --function-name requests-function --cli-binary-format raw-in-base64-out --payload '{"key1": "value1", "key2": "value2", "key3": "value3"}' output.txt
+  aws lambda invoke --function-name my-sourcecode-function --cli-binary-format raw-in-base64-out --payload '{"key1": "value1", "key2": "value2", "key3": "value3"}' output.txt
   ```
 
 ------


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
On lines 391 and 398, the function-name argument was passed as `requests-function`, but the name of the created function is `my-sourcecode-function`. This might be confusing to new comers so I changed those arguments to `my-sourcecode-function` to be in line with the rest of the document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
