### PR TITLE
Update README.md to reference correct filename of cleanup script

### DIFF
--- a/sample-apps/rds-mysql/README.md
+++ b/sample-apps/rds-mysql/README.md
@@ -138,4 +138,4 @@ For more information, see [Configuring database access](https://docs.aws.amazon.
 
 To delete the application, run the cleanup script.
 
-    rds-mysql$ ./8-cleanup.sh
+    rds-mysql$ ./7-cleanup.sh


### PR DESCRIPTION
README.md currently references ./8-cleanup.sh in order to run the cleanup script. This file currently exists in the repo as 7-cleanup.sh

*Issue #, if available:* N/A

*Description of changes:* updated README.md to reference correct filename


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
