### PR TITLE
Remove Unused Variable

### DIFF
--- a/sample-apps/java-events/src/main/java/example/HandlerApiGateway.java
+++ b/sample-apps/java-events/src/main/java/example/HandlerApiGateway.java
@@ -18,7 +18,6 @@ public class HandlerApiGateway implements RequestHandler<APIGatewayProxyRequestE
   @Override
   public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent event, Context context)
   {
-    LambdaLogger logger = context.getLogger();
     APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
     response.setIsBase64Encoded(false);
     response.setStatusCode(200);

--- a/sample-apps/java-events/src/main/java/example/HandlerApiGateway.java
+++ b/sample-apps/java-events/src/main/java/example/HandlerApiGateway.java
@@ -2,7 +2,6 @@ package example;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 


### PR DESCRIPTION
*Issue #, if available:*
`logger` is unused since `Util.logEnvironment()` is doing the logging. 

*Description of changes:*
Remove the unused Logger and its import.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
