### PR TITLE
fix: use payload file protocol accordingly Aws Cli version

### DIFF
--- a/sample-apps/blank-csharp/3-invoke.sh
+++ b/sample-apps/blank-csharp/3-invoke.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name blank-csharp --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
-
+if [[ $(aws --version) =~ "aws-cli/2." ]]; then PAYLOAD_PROTOCOL="fileb"; else  PAYLOAD_PROTOCOL="file"; fi;
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload $PAYLOAD_PROTOCOL://event.json out.json
   cat out.json
   echo ""
   sleep 2


### PR DESCRIPTION
*Issue #180

*Description of changes: Instead of ask user to change his profile, this change detects aws cli version and sends the payload as binary, if it uses v2 cli.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
