### PR TITLE
Move java-events-v1sdk samples to java-events. Add note that v1sdk examples are deprecated.

### DIFF
--- a/sample-apps/java-events-v1sdk/README.md
+++ b/sample-apps/java-events-v1sdk/README.md
@@ -2,6 +2,8 @@
 
 This sample application shows the use of the `aws-lambda-java-events` library with event types that require AWS SDK as a dependency. A separate handler class is defined for each input type. For other event types (which don't require the AWS SDK), see the `java-events` sample.
 
+**Note: The `java-events-v1sdk` examples are deprecated.** As of version 3.0.0 of the `aws-lambda-java-events` package, [users are no longer required to pull in SDK dependencies in order to use that library](https://github.com/aws/aws-lambda-java-libs/tree/master/aws-lambda-java-events). Please see the [`java-events` package](https://github.com/awsdocs/aws-lambda-developer-guide/tree/main/sample-apps/java-events) for updated examples.
+
 ![Architecture](/sample-apps/java-events-v1sdk/images/sample-java-events-v1sdk.png)
 
 The project includes function code and supporting resources:

--- a/sample-apps/java-events/3-invoke.sh
+++ b/sample-apps/java-events/3-invoke.sh
@@ -25,11 +25,20 @@ then
     cog)
       PAYLOAD='file://events/cognito-sync.json'
       ;;
+    kin)
+      PAYLOAD='file://events/kinesis-record.json'
+      ;;
     fh)
       PAYLOAD='file://events/firehose-record.json'
       ;;
     lex)
       PAYLOAD='file://events/lex-flowers.json'
+      ;;
+    ddb)
+      PAYLOAD='file://events/dynamodb-record.json'
+      ;;
+    s3)
+      PAYLOAD='file://events/s3-notification.json'
       ;;
     *)
       echo -n "Unknown event type"

--- a/sample-apps/java-events/README.md
+++ b/sample-apps/java-events/README.md
@@ -90,8 +90,11 @@ By default, the function uses a handler class named `Handler` that takes an API 
 - `HandlerCognito.java` - Takes `CognitoEvent` as input.
 - `HandlerCWEvents.java` - Takes `ScheduledEventEvent` as input.
 - `HandlerCWLogs.java` - Takes `CloudWatchLogsEvent` as input.
+- `HandlerDynamoDB.java` - Takes `DynamodbEvent` as input.
 - `HandlerFirehose.java` - Takes `KinesisFirehoseEvent` as input.
+- `HandlerKinesis.java` - Takes `KinesisEvent` as input.
 - `HandlerLex.java` - Takes `LexEvent` as input.
+- `HandlerS3.java` - Takes `S3Event` as input.
 - `HandlerSNS.java` - Takes `SNSEvent` as input.
 
 To use a different handler, change the value of the Handler setting in the application template (`template.yml` or `template-mvn.yaml`). For example, to use the Amazon Lex handler:
@@ -118,8 +121,11 @@ The following event type keys are supported:
 - `cfg` - Config rule (`events/config-rule.json`)
 - `cc` - CodeCommit push (`events/codecommit-push.json`)
 - `cog` - Cognito Sync (`events/cognito-sync.json`)
+- `kin` - Kinesis record (`events/kinesis-record.json`)
 - `fh` - Kinesis Firehose record (`events/firehose-record.json`)
 - `lex` - Lex dialog (`events/lex-flowers.json`)
+- `ddb` - DynamoDB record (`events/dynamodb-record.json`)
+- `s3` - S3Event record (`events/s3-notification.json`)
 
 # Cleanup
 To delete the application, run `4-cleanup.sh`.

--- a/sample-apps/java-events/build.gradle
+++ b/sample-apps/java-events/build.gradle
@@ -8,11 +8,11 @@ repositories {
 
 dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
-    implementation 'com.amazonaws:aws-lambda-java-events:2.2.9'
+    implementation 'com.amazonaws:aws-lambda-java-events:3.9.0'
     implementation 'com.google.code.gson:gson:2.8.6'
-    testImplementation 'org.apache.logging.log4j:log4j-api:2.13.0'
-    testImplementation 'org.apache.logging.log4j:log4j-core:2.13.0'
-    testImplementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.13.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.13.0'
+    implementation 'org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
 }

--- a/sample-apps/java-events/events/dynamodb-record.json
+++ b/sample-apps/java-events/events/dynamodb-record.json
@@ -1,0 +1,64 @@
+{
+  "Records": [
+    {
+      "eventID": "1",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "Keys": {
+          "Id": {
+            "N": "101"
+          }
+        },
+        "NewImage": {
+          "Message": {
+            "S": "New item!"
+          },
+          "Id": {
+            "N": "101"
+          }
+        },
+        "StreamViewType": "NEW_AND_OLD_IMAGES",
+        "SequenceNumber": "111",
+        "SizeBytes": 26
+      },
+      "awsRegion": "us-west-2",
+      "eventName": "INSERT",
+      "eventSourceARN": "eventsourcearn",
+      "eventSource": "aws:dynamodb"
+    },
+    {
+      "eventID": "2",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "OldImage": {
+          "Message": {
+            "S": "New item!"
+          },
+          "Id": {
+            "N": "101"
+          }
+        },
+        "SequenceNumber": "222",
+        "Keys": {
+          "Id": {
+            "N": "101"
+          }
+        },
+        "SizeBytes": 59,
+        "NewImage": {
+          "Message": {
+            "S": "This item has changed"
+          },
+          "Id": {
+            "N": "101"
+          }
+        },
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "awsRegion": "us-west-2",
+      "eventName": "MODIFY",
+      "eventSourceARN": "sourcearn",
+      "eventSource": "aws:dynamodb"
+    }
+  ]
+}

--- a/sample-apps/java-events/events/kinesis-record.json
+++ b/sample-apps/java-events/events/kinesis-record.json
@@ -1,0 +1,36 @@
+{
+    "Records": [
+        {
+            "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "1",
+                "sequenceNumber": "49590338271490256608559692538361571095921575989136588898",
+                "data": "SGVsbG8sIHRoaXMgaXMgYSB0ZXN0Lg==",
+                "approximateArrivalTimestamp": 1545084650.987
+            },
+            "eventSource": "aws:kinesis",
+            "eventVersion": "1.0",
+            "eventID": "shardId-000000000006:49590338271490256608559692538361571095921575989136588898",
+            "eventName": "aws:kinesis:record",
+            "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+            "awsRegion": "us-east-2",
+            "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+        },
+        {
+            "kinesis": {
+                "kinesisSchemaVersion": "1.0",
+                "partitionKey": "1",
+                "sequenceNumber": "49590338271490256608559692540925702759324208523137515618",
+                "data": "VGhpcyBpcyBvbmx5IGEgdGVzdC4=",
+                "approximateArrivalTimestamp": 1545084711.166
+            },
+            "eventSource": "aws:kinesis",
+            "eventVersion": "1.0",
+            "eventID": "shardId-000000000006:49590338271490256608559692540925702759324208523137515618",
+            "eventName": "aws:kinesis:record",
+            "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+            "awsRegion": "us-east-2",
+            "eventSourceARN": "arn:aws:kinesis:us-east-2:123456789012:stream/lambda-stream"
+        }
+    ]
+}

--- a/sample-apps/java-events/events/s3-notification.json
+++ b/sample-apps/java-events/events/s3-notification.json
@@ -1,0 +1,39 @@
+{
+    "Records": [
+        {
+            "awsRegion": "us-east-2",
+            "eventName": "ObjectCreated:Put",
+            "eventSource": "aws:s3",
+            "eventTime": "2020-03-08T00:30:12.456Z",
+            "eventVersion": "2.1",
+            "requestParameters": {
+                "sourceIPAddress": "174.255.255.156"
+            },
+            "responseElements": {
+                "xAmzId2": "nBbLJPAHhdvxmplPvtCgTrWCqf/KtonyV93l9rcoMLeIWJxpS9x9P8u01+Tj0OdbAoGs+VGvEvWl/Sg1NW5uEsVO25Laq7L",
+                "xAmzRequestId": "AF2D7AB6002E898D"
+            },
+            "s3": {
+                "configurationId": "682bbb7a-xmpl-48ca-94b1-7f77c4d6dbf0",
+                "bucket": {
+                    "name": "BUCKET_NAME",
+                    "ownerIdentity": {
+                        "principalId": "A3XMPLFAF2AI3E"
+                    },
+                    "arn": "arn:aws:s3:::BUCKET_NAME"
+                },
+                "object": {
+                    "key": "inbound/sample-java-s3.png",
+                    "size": 21476,
+                    "eTag": "d132690b6c65b6d1629721dcfb49b883",
+                    "versionId": "",
+                    "sequencer": "005E64A65DF093B26D"
+                },
+                "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+                "principalId": "AWS:AIDAINPONIXMPLT3IKHL2"
+            }
+        }
+    ]
+}

--- a/sample-apps/java-events/pom.xml
+++ b/sample-apps/java-events/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>2.2.9</version>
+      <version>3.9.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -31,32 +31,29 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>2.13.0</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>2.13.2</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j18-impl</artifactId>
       <version>2.13.0</version>
-      <scope>test</scope>
     </dependency>
-   <dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.6.0</version>
       <scope>test</scope>
-   </dependency>
-   <dependency>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.6.0</version>
       <scope>test</scope>
-   </dependency>
+    </dependency>
   </dependencies>
 
   <build>

--- a/sample-apps/java-events/src/main/java/example/HandlerDynamoDB.java
+++ b/sample-apps/java-events/src/main/java/example/HandlerDynamoDB.java
@@ -1,0 +1,33 @@
+package example;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Handler value: example.HandlerDynamoDB
+public class HandlerDynamoDB implements RequestHandler<DynamodbEvent, String>{
+  private static final Logger logger = LoggerFactory.getLogger(HandlerDynamoDB.class);
+  Gson gson = new GsonBuilder().setPrettyPrinting().create();
+  @Override
+  public String handleRequest(DynamodbEvent event, Context context)
+  {
+    String response = new String("200 OK");
+    for (DynamodbStreamRecord record : event.getRecords()){
+      logger.info(record.getEventID());
+      logger.info(record.getEventName());
+      logger.info(record.getDynamodb().toString());
+    }
+    logger.info("Successfully processed " + event.getRecords().size() + " records.");
+    // log execution details
+    Util.logEnvironment(event, context, gson);
+    return response;
+  }
+}

--- a/sample-apps/java-events/src/main/java/example/HandlerKinesis.java
+++ b/sample-apps/java-events/src/main/java/example/HandlerKinesis.java
@@ -1,0 +1,30 @@
+package example;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent.KinesisEventRecord;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Handler value: example.HandleKinesis
+public class HandlerKinesis implements RequestHandler<KinesisEvent, String>{
+  private static final Logger logger = LoggerFactory.getLogger(HandlerKinesis.class);
+  Gson gson = new GsonBuilder().setPrettyPrinting().create();
+  @Override
+  public String handleRequest(KinesisEvent event, Context context)
+  {
+    String response = new String("200 OK");
+    for(KinesisEventRecord record : event.getRecords()) {
+      logger.info(gson.toJson(record.getKinesis().getData()));
+    }
+    // log execution details
+    Util.logEnvironment(event, context, gson);
+    return response;
+  }
+}

--- a/sample-apps/java-events/src/main/java/example/HandlerS3.java
+++ b/sample-apps/java-events/src/main/java/example/HandlerS3.java
@@ -1,0 +1,35 @@
+package example;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.events.S3Event;
+
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification.S3EventNotificationRecord;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Handler value: example.Handler
+public class HandlerS3 implements RequestHandler<S3Event, String>{
+    private static final Logger logger = LoggerFactory.getLogger(HandlerS3.class);
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    @Override
+    public String handleRequest(S3Event event, Context context)
+    {
+        String response = new String("200 OK");
+        S3EventNotificationRecord record = event.getRecords().get(0);
+        String srcBucket = record.getS3().getBucket().getName();
+        // Object key may have spaces or unicode non-ASCII characters.
+        String srcKey = record.getS3().getObject().getUrlDecodedKey();
+        logger.info("RECORD: " + record);
+        logger.info("SOURCE BUCKET: " + srcBucket);
+        logger.info("SOURCE KEY: " + srcKey);
+        // log execution details
+        Util.logEnvironment(event, context, gson);
+        return response;
+    }
+}

--- a/sample-apps/java-events/src/main/resources/log4j2.xml
+++ b/sample-apps/java-events/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<Configuration status="WARN">
+  <Appenders>
+    <Lambda name="Lambda">
+      <PatternLayout>
+          <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+      </PatternLayout>
+    </Lambda>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="Lambda"/>
+    </Root>
+    <Logger name="software.amazon.awssdk" level="WARN" />
+    <Logger name="software.amazon.awssdk.request" level="DEBUG" />
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
With the introduction of [version 3.0.0 of the `aws-lambda-java-events` library](https://github.com/aws/aws-lambda-java-libs/tree/master/aws-lambda-java-events), explicitly pulling in the SDK as a dependency is no longer required. Thus, the current samples found in the [`java-events-v1sdk` package](https://github.com/awsdocs/aws-lambda-developer-guide/tree/main/sample-apps/java-events-v1sdk) can be updated to remove the SDK dependencies.

*Description of changes:*

Three examples from `java-events-v1sdk`, [Handler.java (S3)](https://github.com/awsdocs/aws-lambda-developer-guide/blob/main/sample-apps/java-events-v1sdk/src/main/java/example/Handler.java), [HandlerDynamoDB.java](https://github.com/awsdocs/aws-lambda-developer-guide/blob/main/sample-apps/java-events-v1sdk/src/main/java/example/HandlerDynamoDB.java), and [HandlerKinesis.java](https://github.com/awsdocs/aws-lambda-developer-guide/blob/main/sample-apps/java-events-v1sdk/src/main/java/example/HandlerKinesis.java) are copied over to the [`java-events` package](https://github.com/awsdocs/aws-lambda-developer-guide/tree/main/sample-apps/java-events). I have tested this change by building the package with both Gradle and Maven, as well as testing invocation for each supported handler. README was also updated to reflect changes.

The old `java-events-v1sdk` package will be untouched in order to keep the examples for customers running versions lower than 3.0.0. However, a note has been added to that package's README stating that these examples have been deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
