### PR TITLE
fix function name in code sample

### DIFF
--- a/doc_source/python-package-create.md
+++ b/doc_source/python-package-create.md
@@ -434,7 +434,7 @@ You can now delete the resources that you created for this tutorial, unless you 
 + Use the [delete\-function](https://docs.aws.amazon.com/cli/latest/reference/lambda/delete-function.html) command\.
 
   ```
-  aws lambda delete-function --function-name my-function
+  aws lambda delete-function --function-name my-sourcecode-function
   ```
 
   This command produces no output\.


### PR DESCRIPTION
*Issue #: n/a*

*Minor fix, almost too small for a PR:*

The function name in the code sample to delete the lambda function in the _Creating a function with runtime dependencies_ section has presumably been copied from the previous _Creating a function without runtime dependencies_ section; the lambda functions have different names in both sections, though; probably a classic copy-and-paste mistake...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
