### PR TITLE
Update lambda-runtimes.md

### DIFF
--- a/doc_source/lambda-runtimes.md
+++ b/doc_source/lambda-runtimes.md
@@ -12,7 +12,7 @@ When you use a \.zip file archive for the deployment package, you choose a runti
 + Image – Custom
 + Linux kernel – 4\.14\.165\-102\.205\.amzn2\.x86\_64
 
-When your function is invoked, Lambda attempts to re\-use the execution environment from a previous invocation if one is available\. This saves time preparing the execution environment, and it allows you to save resources such as database connections and temporary files in the [execution environment](runtimes-context.md) to avoid creating them every time your function runs\.
+When your function is invoked, Lambda attempts to re\-use the execution environment from a previous invocation if one is available\. When an [execution environment](runtimes-context.md) is reused, time is saved because your resources, such as database connections and temporary files, do not have to be recreated before your function runs\.
 
 A runtime can support a single version of a language, multiple versions of a language, or multiple languages\. Runtimes specific to a language or framework version are [deprecated](runtime-support-policy.md) when the version reaches end of life\.
 


### PR DESCRIPTION
This  sentence is problematic "This saves time preparing the execution environment, and it allows you to save resources such as database connections and temporary files in the execution environment to avoid creating them every time your function runs." 

The "This" is referring to an "attempt" to re-use an environment, which is different than an environment actually being reused. The "attempt" doesn't in itself save time.

The phrase "and it allows you to save resources such as database connections " is implying that the user can take certain actions because of the attempt that is made by Lambda to re-use an environment when in reality the users actions are the same regardless of whether the execution environment is reused or not. The sentence should be more clear than Lambda is doing the work. 

The phrase "creating them every time your function runs." is awkward because when an execution environment is reused the resources do not have to be recreated for that particular invocation of the function, but it should not be said that the savings applies to "every time your functions runs"  

Thank you for taking the time to review my proposed changes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
