### PR TITLE
Fix incorrect value for maxBytes + add missing comma + format

### DIFF
--- a/doc_source/runtimes-logs-api.md
+++ b/doc_source/runtimes-logs-api.md
@@ -79,20 +79,21 @@ The following example shows a request to subscribe to the platform and function 
 
 ```
 PUT http://${AWS_LAMBDA_RUNTIME_API}/2020-08-15/logs/ HTTP/1.1
-{ "schemaVersion": "2020-08-15",
-  "types": [
-      "platform",
-      "function"
+{
+    "schemaVersion": "2020-08-15",
+    "types": [
+        "platform",
+        "function"
     ],
-  "buffering": {
-      "maxItems": 1000,
-      "maxBytes": 10240,
-      "timeoutMs": 100
+    "buffering": {
+        "maxItems": 1000,
+        "maxBytes": 262144,
+        "timeoutMs": 100
+    },
+    "destination": {
+        "protocol": "HTTP",
+        "URI": "http://sandbox.localdomain:8080/lambda_logs"
     }
-  "destination": {
-    "protocol": "HTTP",
-    "URI": "http://sandbox.localdomain:8080/lambda_logs"
-  }
 }
 ```
 


### PR DESCRIPTION
*Description of changes:*

- add missing comma after the `buffering` object
- change the invalid value for `maxBytes`
- correct indentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
