### PR TITLE
Update handler function name

### DIFF
--- a/doc_source/services-rds-tutorial.md
+++ b/doc_source/services-rds-tutorial.md
@@ -99,7 +99,7 @@ except pymysql.MySQLError as e:
     sys.exit()
 
 logger.info("SUCCESS: Connection to RDS MySQL instance succeeded")
-def handler(event, context):
+def lambda_handler(event, context):
     """
     This function fetches content from MySQL RDS instance
     """


### PR DESCRIPTION
The example lambda code has the handler name as `handler`. It seems that lambda now expects `lambda_handler`.

*Issue #, if available:*

*Description of changes:* Changing the function name so the code will run inside lambda.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
