### PR TITLE
Add command to cd into project directory

### DIFF
--- a/doc_source/csharp-package-cli.md
+++ b/doc_source/csharp-package-cli.md
@@ -162,6 +162,7 @@ For more information about the Amazon\.Lambda\.Tools \.NET Core Global Tool, see
 With the Amazon\.Lambda\.Tools installed, you can deploy your function using the following command:
 
 ```
+cd MyFunction/src/MyFunction
 dotnet lambda deploy-function MyFunction --function-role role
 ```
 


### PR DESCRIPTION
Following this guide as is, when someone runs the deploy function, it shows error
```
No .NET project found in directory .../MyFunction to build.
```
users need to cd into the director that has MyFunction.csproj file

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
