### PR TITLE
Fix name of Lambda console section heading

### DIFF
--- a/doc_source/services-apigateway.md
+++ b/doc_source/services-apigateway.md
@@ -26,7 +26,7 @@ Resources in your API define one or more methods, such as GET or POST\. Methods 
 
 1. Choose a function\.
 
-1. Under **Functional overview**, choose **Add trigger**\.
+1. Under **Function overview**, choose **Add trigger**\.
 
 1. Select **API Gateway**\.
 


### PR DESCRIPTION
*Description of changes:*

The section is called `Function overview`, not `Functional overview`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
