### PR TITLE
Fixing log4j-maven-shade-plugin-extensions dependency

### DIFF
--- a/sample-apps/blank-java/pom.xml
+++ b/sample-apps/blank-java/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.4</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>
@@ -108,7 +108,7 @@
             </goals>
             <configuration>
               <transformers>
-                <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
+                <transformer implementation="io.github.edwgiz.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer">
                 </transformer>
               </transformers>
             </configuration>
@@ -116,9 +116,9 @@
         </executions>
         <dependencies>
           <dependency>
-            <groupId>com.github.edwgiz</groupId>
-            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-            <version>2.17.0</version>
+            <groupId>io.github.edwgiz</groupId>
+            <artifactId>log4j-maven-shade-plugin-extensions</artifactId>
+            <version>2.17.1</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing 
<groupId>io.github.edwgiz</groupId>
            <artifactId>log4j-maven-shade-plugin-extensions</artifactId>
            <version>2.17.1</version>
Dependency in lambda samples.
Ref: 
https://mvnrepository.com/artifact/io.github.edwgiz/log4j-maven-shade-plugin-extensions/2.17.1
https://github.com/edwgiz/maven-shaded-log4j-transformer/tree/2.17.1