### PR TITLE
Replace curly quotes in code block

### DIFF
--- a/doc_source/configuration-vpc-endpoints.md
+++ b/doc_source/configuration-vpc-endpoints.md
@@ -97,8 +97,8 @@ You need to include both the qualified and the unqualified function ARN in the r
             "lambda:InvokeFunction"
          ],
          "Resource": [
-               "arn:aws:lambda:us-east-2:123456789012:function:my-function”,
-               "arn:aws:lambda:us-east-2:123456789012:function:my-function:*”
+               "arn:aws:lambda:us-east-2:123456789012:function:my-function",
+               "arn:aws:lambda:us-east-2:123456789012:function:my-function:*"
             ]
       }
    ]


### PR DESCRIPTION
This removes the extraneous JSON syntax highlighting in the code block in https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc-endpoints.html#vpc-endpoint-policy.

*Issue #, if available:*

*Description of changes:* Replaces curly quotes (closing double quotation marks) with straight quotes. Before this change, the JSON is malformed and syntax highlighting doesn't work correctly. After this change, the JSON is valid.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
