### PR TITLE
GOARCH amd64

### DIFF
--- a/sample-apps/blank-go/2-deploy.sh
+++ b/sample-apps/blank-go/2-deploy.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 ARTIFACT_BUCKET=$(cat bucket-name.txt)
 cd function
-GOOS=linux go build main.go
+GOOS=linux GOARCH=amd64 go build main.go
 cd ../
 aws cloudformation package --template-file template.yml --s3-bucket $ARTIFACT_BUCKET --output-template-file out.yml
 aws cloudformation deploy --template-file out.yml --stack-name blank-go --capabilities CAPABILITY_NAMED_IAM


### PR DESCRIPTION
*Issue #, NA*

*Description of changes:*
Add GOARCH=amd64 To ensure the go sample is compiled for x86 when being run from ARM or other systems.

Without this when running from my M1 machine the lambda errored with `fork/exec /var/task/main: exec format error: PathError null`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
