### PR TITLE
Update with-s3-example.md

### DIFF
--- a/doc_source/with-s3-example.md
+++ b/doc_source/with-s3-example.md
@@ -164,7 +164,7 @@ Invoke the Lambda function manually using sample Amazon S3 event data\.
 
    1. For **Event name**, enter a name for the test event\. For example, **mys3testevent**\.
 
-   1. In the test event JSON, replace the S3 bucket name \(`example-bucket`\) and object key \(`test/key`\) with your bucket name and test file name\. Your test event should look similar to the following:
+   1. In the test event JSON, replace the S3 bucket name \(`example-bucket`\) and object key \(`test%2Fkey`\) with your bucket name and test file name (that you uploaded in your bucket)\. Your test event should look similar to the following:
 
       ```
       {
@@ -193,7 +193,7 @@ Invoke the Lambda function manually using sample Amazon S3 event data\.
                 "ownerIdentity": {
                   "principalId": "EXAMPLE"
                 },
-                "arn": "arn:aws:s3:::example-bucket"
+                "arn": "arn:aws:s3:::my-s3-bucket"
               },
               "object": {
                 "key": "HappyFace.jpg",


### PR DESCRIPTION
In the Event JSON (Heading: Test in the console, Point: 2. iv), for the key "arn", the value "example-bucket" was written. Ideally, it should be "my-s3-bucket" because "my-s3-bucket" is the value for the bucket name.

Also, in the test event JSON template that is provided in the "Configure test event" menu on lambda function's page, test/key is written as "test%2Fkey". So, updated that as well.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
