### PR TITLE
Update to APIGatewayHttpApiV2ProxyResponse

### DIFF
--- a/doc_source/csharp-handler.md
+++ b/doc_source/csharp-handler.md
@@ -131,7 +131,7 @@ public partial class HttpApiJsonSerializerContext : JsonSerializerContext
 
 public class Functions
 {
-    public APIGatewayProxyResponse Get(APIGatewayHttpApiV2ProxyRequest
+    public APIGatewayHttpApiV2ProxyResponse Get(APIGatewayHttpApiV2ProxyRequest
 request, ILambdaContext context)
     {
         context.Logger.LogInformation("Get Request");


### PR DESCRIPTION
*Issue #, if available:* I coped this sample and needed this change to get it to build

*Description of changes:* Updating APIGatewayProxyResponse return type to APIGatewayHttpApiV2ProxyResponse


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
