### PR TITLE
Update log4j shade plugin to log4j-maven-shade-plugin-extensions

### DIFF
--- a/sample-apps/blank-java/pom.xml
+++ b/sample-apps/blank-java/pom.xml
@@ -108,16 +108,15 @@
             </goals>
             <configuration>
               <transformers>
-                <transformer implementation="com.github.edwgiz.maven_shade_plugin.log4j2_cache_transformer.PluginsCacheFileTransformer">
-                </transformer>
+                <transformer implementation="io.github.edwgiz.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
               </transformers>
             </configuration>
           </execution>
         </executions>
         <dependencies>
           <dependency>
-            <groupId>com.github.edwgiz</groupId>
-            <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
+            <groupId>io.github.edwgiz</groupId>
+            <artifactId>log4j-maven-shade-plugin-extensions</artifactId>
             <version>[2.17.1,)</version>
           </dependency>
         </dependencies>


### PR DESCRIPTION
The dependency has been moved by author to https://mvnrepository.com/artifact/io.github.edwgiz/log4j-maven-shade-plugin-extensions

*Description of changes:*
Updated pom.xml as per documentation at https://github.com/edwgiz/maven-shaded-log4j-transformer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
