### PR TITLE
Relationship between Lambda alias and function version

### DIFF
--- a/doc_source/configuration-aliases.md
+++ b/doc_source/configuration-aliases.md
@@ -1,6 +1,6 @@
 # Lambda function aliases<a name="configuration-aliases"></a>
 
-You can create one or more aliases for your Lambda function\. A Lambda alias is like a pointer to a specific function version\. Users can access the function version using the alias Amazon Resource Name \(ARN\)\.
+You can create one or more aliases for your Lambda function\. A Lambda alias is like a pointer to a specific function version with the exception that it can point to two function versions during [traffic shifting](https://aws.amazon.com/about-aws/whats-new/2017/11/aws-lambda-supports-traffic-shifting-and-phased-deployments-with-aws-codedeploy/)\. Users can access the function version using the alias Amazon Resource Name \(ARN\)\.
 
 **Topics**
 + [Creating a function alias \(Console\)](#configuration-aliases-config)


### PR DESCRIPTION
Updated the relationship between Lambda alias and function version.

*Issue #, if available:*
The uniquely identifiable relationship from Lambda alias to a function version doesn't hold true during Lambda traffic shifting. 

*Description of changes:*
Clear the confusion of relationship between Lambda alias and function version. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
