### PR TITLE
Fully define KB/MB/GB units to mean base-2

### DIFF
--- a/doc_source/gettingstarted-limits.md
+++ b/doc_source/gettingstarted-limits.md
@@ -22,7 +22,7 @@ For details on concurrency and how Lambda scales your function concurrency in re
 The following quotas apply to function configuration, deployment, and execution\. They cannot be changed\.
 
 **Note**  
-The Lambda documentation, log messages, and console use the abbreviation MB \(rather than MiB\) to refer to 1024 KB\.
+The Lambda documentation, log messages, and console use the abbreviation KB/MB/GB \(rather than KiB/MiB/GiB\) to mean 1024/1024<sup>2</sup>/1024<sup>3</sup> bytes.
 
 
 | Resource | Quota | 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
The doc used KB/GB without defining them as base-2, and MB was under-defined (based on KB). 

This change fully defines all ambiguous units of data size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
