### PR TITLE
:doc: wrong API type for template compatability

### DIFF
--- a/doc_source/services-apigateway-blueprint.md
+++ b/doc_source/services-apigateway-blueprint.md
@@ -26,7 +26,7 @@ Follow the steps in this section to create a new Lambda function and an API Gate
    + **Role name** – **lambda\-apigateway\-role**\.
    + **Policy templates** – **Simple microservice permissions**\.
    + **API** – **Create an API**\.
-   + **API Type** – **HTTP API**\.
+   + **API Type** – **REST API**\.
    + **Security** – **Open**\.
 
    Choose **Create function**\.


### PR DESCRIPTION
# Explination

So if you follow along with [these](https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway-blueprint.html) instructions for the "Create a simple microservice using Lambda and API Gateway" tutorial and actually try to test the endpoint via postman or curl you will realize that you will get a server error because the lambda function is failing when trying to parse the event json data for "httpMethod". The "httpMethod" key will only be found in events generated by API gateway when it is configured as a REST API instead of an HTTP API. You can see below the differences. Basically, the microservice lambda template code which performs actions on the  DynamoDB resource is set up to work out of the box for REST API gateway body format and not HTTP API's. See below for comparing the body of the HTTP API vs REST API.

## HTTP API Event Data Payload structure:

```
"requestContext": {
        "accountId": "391741500388",
        "apiId": "lh8rxrmng8",
        "domainName": "lh8rxrmng8.execute-api.us-east-1.amazonaws.com",
        "domainPrefix": "lh8rxrmng8",
        "http": {
            "method": "GET",
             .
             .
             .
```



## API Event Data Payload structure:

```
"resource": "/lambda-microservice2",
"path": "/lambda-microservice2",
"httpMethod": "GET",
"headers": {
.
.
.
```


*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
