### PR TITLE
use `go install` to install `build-lambda-zip`.

### DIFF
--- a/doc_source/golang-package.md
+++ b/doc_source/golang-package.md
@@ -88,7 +88,7 @@ If you have not already done so, you must install [git](https://git-scm.com/) an
 1. Download the **build\-lambda\-zip** tool from GitHub:
 
    ```
-   go.exe get -u github.com/aws/aws-lambda-go/cmd/build-lambda-zip
+   go.exe install github.com/aws/aws-lambda-go/cmd/build-lambda-zip@latest
    ```
 
 1. Use the tool from your `GOPATH` to create a \.zip file\. If you have a default installation of Go, the tool is typically in `%USERPROFILE%\Go\bin`\. Otherwise, navigate to where you installed the Go runtime and do one of the following:


### PR DESCRIPTION
*Issue #, if available:*

fixes https://github.com/aws/aws-lambda-go/issues/463

*Description of changes:*

go 1.18 removed the ability to use `go get` to install binaries.
we should use `go install` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
