### PR TITLE
Update python-package.md

### DIFF
--- a/doc_source/python-package.md
+++ b/doc_source/python-package.md
@@ -100,7 +100,7 @@ Create the \.zip file for your deployment package\.
 1. Copy the contents of the following sample Python code and save it in a new file named `lambda_function.py`:
 
    ```
-   import requests
+   import requests  # I recommend using a different package because requests is now included in base python3.7+
    def lambda_handler(event, context):   
        response = requests.get("https://www.test.com/")
        print(response.text)


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
For deploying packages with python dependencies, the requests package is used.  Since requests now comes bundled into python3.7+ I suggest you choose a different package and code snippet.  Sure, this still illustrates the point of bundling, but might give the user a false sense of security if they forgot the pip install command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
