### PR TITLE
Add info: timing out long-running lambda functions

### DIFF
--- a/doc_source/API_Invoke.md
+++ b/doc_source/API_Invoke.md
@@ -6,6 +6,14 @@ For [synchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invoca
 
 When an error occurs, your function may be invoked multiple times\. Retry behavior varies by error type, client, event source, and invocation type\. For example, if you invoke a function asynchronously and it returns an error, Lambda executes the function up to two more times\. For more information, see [Retry Behavior](https://docs.aws.amazon.com/lambda/latest/dg/retries-on-errors.html)\.
 
+Invoking long-running Lambda functions synchonously under default CLI parameters will lead to the functions being retried after the default timeout of 60 seconds is reached regardless of their actual timeout. To prevent this from happening, you could specify the `--cli-read-timeout` option to the number of seconds to wait before timing out or you could query the timeout before invokation issuing, `aws lambda invoke --function-name LAMBDA_NAME --payload PAYLOAD --cli-read-timeout $(aws lambda-timeout LAMBDA_NAME) output.temp`. This query can be done with an alias such as the following,
+```
+lambda-timeout =
+  !f() {
+    aws lambda get-function-configuration --function-name "$1" --query Timeout --output text
+  }; f
+```
+
 For [asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html), Lambda adds events to a queue before sending them to your function\. If your function does not have enough capacity to keep up with the queue, events may be lost\. Occasionally, your function may receive the same event multiple times, even if no error occurs\. To retain events that were not processed, configure your function with a [dead\-letter queue](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#dlq)\.
 
 The status code in the API response doesn't reflect function errors\. Error codes are reserved for errors that prevent your function from executing, such as permissions errors, [limit errors](https://docs.aws.amazon.com/lambda/latest/dg/limits.html), or issues with your function's code and configuration\. For example, Lambda returns `TooManyRequestsException` if executing the function would cause you to exceed a concurrency limit at either the account level \(`ConcurrentInvocationLimitExceeded`\) or function level \(`ReservedFunctionConcurrentInvocationLimitExceeded`\)\.

--- a/doc_source/invocation-sync.md
+++ b/doc_source/invocation-sync.md
@@ -6,6 +6,14 @@ When you invoke a function synchronously, Lambda runs the function and waits for
 aws lambda invoke --function-name my-function --cli-binary-format raw-in-base64-out --payload '{ "key": "value" }' response.json
 ```
 
+Lambda functions invoked synchronoysly using the AWS CLI under default conditions are subject to the default time out of 60 seconds. For long-running Lambda functions this will lead to them being retried regardless of their actual timeout. To prevent this from happening, you could specify the `--cli-read-timeout` option to the number of seconds to wait before timing out or you could query the timeout before invokation issuing `aws lambda invoke --function-name LAMBDA_NAME --payload PAYLOAD --cli-read-timeout $(aws lambda-timeout LAMBDA_NAME) output.temp`. This query can be done with an alias such as the following,
+```
+lambda-timeout =
+  !f() {
+    aws lambda get-function-configuration --function-name "$1" --query Timeout --output text
+  }; f
+```
+
 The cli\-binary\-format option is required if you are using AWS CLI version 2\. You can also configure this option in your [AWS CLI config file](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-binaryparam)\.
 
 You should see the following output:


### PR DESCRIPTION
There is an information gap regarding long-running lambda functions invoked synchronously via the AWS CLI under default conditions. Two possible solutions to address this are included, these are mentioned [here](https://github.com/aws/aws-cli/issues/2657).

*Issue #, if available:*
aws/aws-cli/issues/5904
aws/aws-cli/issues/2657

*Description of changes:*
Adding a paragraph describing the default timeouts applying to Lambda function invoked synchronously via the AWS CLI with two possible ways to to address the issue, both mentioned in the issues referenced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
