### PR TITLE
fix(sec): upgrade com.amazonaws:aws-java-sdk-s3 to 1.12.261

### DIFF
--- a/sample-apps/java-events-v1sdk/pom.xml
+++ b/sample-apps/java-events-v1sdk/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.11.578</version>
+      <version>1.12.261</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.amazonaws:aws-java-sdk-s3 1.11.578
- [CVE-2022-31159](https://www.oscs1024.com/hd/CVE-2022-31159)


### What did I do？
Upgrade com.amazonaws:aws-java-sdk-s3 from 1.11.578 to 1.12.261 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS