### PR TITLE
Correct timeout output in Go sample

### DIFF
--- a/doc_source/golang-context.md
+++ b/doc_source/golang-context.md
@@ -69,7 +69,7 @@ func LongRunningHandler(ctx context.Context) (string, error) {
                 select {
 
                 case <- timeoutChannel:
-                        return "Finished before timing out.", nil
+                        return "Timed out before finishing.", nil
 
                 default:
                         log.Print("hello!")


### PR DESCRIPTION
*Description of changes:*

Correct the logging output of the Go timeout example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
