### PR TITLE
Use COPY instead of ADD in Dockerfiles

### DIFF
--- a/doc_source/go-image.md
+++ b/doc_source/go-image.md
@@ -76,10 +76,10 @@ Note that the first three steps are identical whether you deploy your function a
    RUN yum install -y golang
    RUN go env -w GOPROXY=direct
    # cache dependencies
-   ADD go.mod go.sum ./
+   COPY go.mod go.sum ./
    RUN go mod download
    # build
-   ADD . .
+   COPY . .
    RUN go build -o /main
    # copy artifacts to a clean image
    FROM public.ecr.aws/lambda/provided:al2
@@ -118,10 +118,10 @@ FROM alpine as build
 RUN apk add go git
 RUN go env -w GOPROXY=direct
 # cache dependencies
-ADD go.mod go.sum ./
+COPY go.mod go.sum ./
 RUN go mod download 
 # build
-ADD . .
+COPY . .
 RUN go build -o /main
 # copy artifacts to a clean image
 FROM alpine


### PR DESCRIPTION
COPY is simpler and less error-prone when not interacting with archives or remote URL content

*Description of changes:*
This does not change the behavior but allows a simpler reading and less complex Dockerfile instructions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
