### PR TITLE
For blank-java, support Maven in 2-build-layer.sh script

### DIFF
--- a/sample-apps/blank-java/2-build-layer.sh
+++ b/sample-apps/blank-java/2-build-layer.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 set -eo pipefail
-gradle -q packageLibs
-mv build/distributions/blank-java.zip build/blank-java-lib.zip
+
+if [ $1 ]
+then
+  if [ $1 = mvn ]
+  then
+    mvn prepare-package
+  fi
+else
+  gradle -q packageLibs
+  mv build/distributions/blank-java.zip build/blank-java-lib.zip
+fi

--- a/sample-apps/blank-java/README.md
+++ b/sample-apps/blank-java/README.md
@@ -43,6 +43,10 @@ To build a Lambda layer that contains the function's runtime dependencies, run `
 
     blank-java$ ./2-build-layer.sh
 
+You can also run this commnand with Maven. To use Maven, add `mvn` to the command.
+
+    blank-java$ ./2-build-layer.sh mvn
+
 # Deploy
 
 To deploy the application, run `3-deploy.sh`.
@@ -55,7 +59,7 @@ To deploy the application, run `3-deploy.sh`.
 
 This script uses AWS CloudFormation to deploy the Lambda functions and an IAM role. If the AWS CloudFormation stack that contains the resources already exists, the script updates it with any changes to the template or function code.
 
-You can also build the application with Maven. To use maven, add `mvn` to the command.
+You can also build the application with Maven. To use Maven, add `mvn` to the command.
 
     java-basic$ ./3-deploy.sh mvn
     [INFO] Scanning for projects...

--- a/sample-apps/blank-java/pom.xml
+++ b/sample-apps/blank-java/pom.xml
@@ -92,6 +92,44 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+                <outputDirectory>
+                    ${project.build.directory}/classes/java/lib
+                </outputDirectory>
+                <includeScope>runtime</includeScope>
+                <excludeScope>test</excludeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>zip.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>

--- a/sample-apps/blank-java/template-mvn.yml
+++ b/sample-apps/blank-java/template-mvn.yml
@@ -25,6 +25,6 @@ Resources:
     Properties:
       LayerName: blank-java-lib
       Description: Dependencies for the blank-java sample app.
-      ContentUri: build/blank-java-lib.zip
+      ContentUri: target/blank-java-1.0-SNAPSHOT.zip
       CompatibleRuntimes:
         - java11

--- a/sample-apps/blank-java/zip.xml
+++ b/sample-apps/blank-java/zip.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>zip</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.directory}/classes/java</directory>
+			<outputDirectory>java/</outputDirectory>
+			<excludes>
+				<exclude>example/</exclude>
+            </excludes>
+		</fileSet>
+	</fileSets>
+</assembly>


### PR DESCRIPTION
Support Maven in 2-build-layer.sh script.

Tested E2E functionality by running through all scripts and ensuring function works as expected.