### PR TITLE
docs(urls-configuration): add missing backslash

### DIFF
--- a/doc_source/urls-configuration.md
+++ b/doc_source/urls-configuration.md
@@ -93,7 +93,7 @@ To create a function URL for an existing Lambda function using the AWS Command L
 aws lambda create-function-url-config \
     --function-name my-function \
     --qualifier prod \ // optional
-    --auth-type AWS_IAM
+    --auth-type AWS_IAM \
     --cors-config {AllowOrigins="https://example.com"} // optional
 ```
 


### PR DESCRIPTION
*Description of changes:*

Hi AWS team! I was just playing around on the documentation and I realized a _backslash_ is missing in the CLI example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
