### PR TITLE
Remove unnecessary null declaration

### DIFF
--- a/sample-apps/blank-java/src/main/java/example/Handler.java
+++ b/sample-apps/blank-java/src/main/java/example/Handler.java
@@ -21,7 +21,7 @@ public class Handler implements RequestHandler<Map<String,String>, String> {
         LambdaLogger logger = context.getLogger();
         logger.log("Handler invoked");
 
-        GetAccountSettingsResponse response = null;
+        GetAccountSettingsResponse response;
         try {
             response = lambdaClient.getAccountSettings();
         } catch(LambdaException e) {


### PR DESCRIPTION
*Description of changes:*
Objects in Java are by default declared as null. Hence, explicit declaration is not required


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
