### PR TITLE
Update template.yml to 18 as version 12 node is no longer compatible

### DIFF
--- a/sample-apps/blank-nodejs/template.yml
+++ b/sample-apps/blank-nodejs/template.yml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs18.x
       CodeUri: function/.
       Description: Call the AWS Lambda API
       Timeout: 10
@@ -25,4 +25,4 @@ Resources:
       Description: Dependencies for the blank sample app.
       ContentUri: lib/.
       CompatibleRuntimes:
-        - nodejs12.x
+        - nodejs18.x


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update template.yml to 18 as version 12 node is no longer compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
