### PR TITLE
Updated field names to match AWS developer guide

### DIFF
--- a/doc_source/services-rds.md
+++ b/doc_source/services-rds.md
@@ -2,7 +2,7 @@
 
 You can use AWS Lambda to process event notifications from an Amazon Relational Database Service \(Amazon RDS\) database\. Amazon RDS sends notifications to an Amazon Simple Notification Service \(Amazon SNS\) topic, which you can configure to invoke a Lambda function\. Amazon SNS wraps the message from Amazon RDS in its own event document and sends it to your function\.
 
-**Example Amazon RDS message in an Amazon SNS event**
+**Example Amazon RDS message in an Amazon SNS event**  
 
 ```
 {
@@ -30,14 +30,12 @@ You can use AWS Lambda to process event notifications from an Amazon Relational 
 ```
 
 **Topics**
-
-- [Tutorial: Configuring a Lambda function to access Amazon RDS in an Amazon VPC](services-rds-tutorial.md)
-- [Configuring the function](#configuration)
++ [Tutorial: Configuring a Lambda function to access Amazon RDS in an Amazon VPC](services-rds-tutorial.md)
++ [Configuring the function](#configuration)
 
 ## Configuring the function<a name="configuration"></a>
 
 The following section shows additional configurations and topics we recommend as part of this tutorial\.
-
-- If too many function instances run concurrently, one or more instances may fail to obtain a database connection\. You can use reserved concurrency to limit the maximum concurrency of the function\. Set the reserved concurrency to be less than the number of database connections\. Reserved concurrency also reserves those instances for this function, which may not be ideal\. If you are invoking the Lambda functions from your application, we recommend you write code that limits the number of concurrent instances\. For more information, see [Managing concurrency for a Lambda function](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html)\.
-- For more information on configuring an Amazon RDS database to send notifications, see [Using Amazon RDS event notifications](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html)\.
-- For more information on using Amazon SNS as trigger, see [Using AWS Lambda with Amazon SNS](with-sns.md)\.
++ If too many function instances run concurrently, one or more instances may fail to obtain a database connection\. You can use reserved concurrency to limit the maximum concurrency of the function\. Set the reserved concurrency to be less than the number of database connections\. Reserved concurrency also reserves those instances for this function, which may not be ideal\. If you are invoking the Lambda functions from your application, we recommend you write code that limits the number of concurrent instances\. For more information, see [Managing concurrency for a Lambda function](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html)\.
++ For more information on configuring an Amazon RDS database to send notifications, see [Using Amazon RDS event notifications](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html)\. 
++ For more information on using Amazon SNS as trigger, see [Using AWS Lambda with Amazon SNS](with-sns.md)\.

--- a/doc_source/services-rds.md
+++ b/doc_source/services-rds.md
@@ -2,7 +2,7 @@
 
 You can use AWS Lambda to process event notifications from an Amazon Relational Database Service \(Amazon RDS\) database\. Amazon RDS sends notifications to an Amazon Simple Notification Service \(Amazon SNS\) topic, which you can configure to invoke a Lambda function\. Amazon SNS wraps the message from Amazon RDS in its own event document and sends it to your function\.
 
-**Example Amazon RDS message in an Amazon SNS event**  
+**Example Amazon RDS message in an Amazon SNS event**
 
 ```
 {
@@ -15,12 +15,12 @@ You can use AWS Lambda to process event notifications from an Amazon Relational 
             "SignatureVersion": "1",
             "Timestamp": "2019-01-02T12:45:07.000Z",
             "Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
-            "SigningCertUrl": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+            "SigningCertURL": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
             "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
             "Message": "{\"Event Source\":\"db-instance\",\"Event Time\":\"2019-01-02 12:45:06.000\",\"Identifier Link\":\"https://console.aws.amazon.com/rds/home?region=eu-west-1#dbinstance:id=dbinstanceid\",\"Source ID\":\"dbinstanceid\",\"Event ID\":\"http://docs.amazonwebservices.com/AmazonRDS/latest/UserGuide/USER_Events.html#RDS-EVENT-0002\",\"Event Message\":\"Finished DB Instance backup\"}",
             "MessageAttributes": {},
             "Type": "Notification",
-            "UnsubscribeUrl": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-2:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+            "UnsubscribeURL": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-2:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
             "TopicArn":"arn:aws:sns:us-east-2:123456789012:sns-lambda",
             "Subject": "RDS Notification Message"
           }
@@ -30,12 +30,14 @@ You can use AWS Lambda to process event notifications from an Amazon Relational 
 ```
 
 **Topics**
-+ [Tutorial: Configuring a Lambda function to access Amazon RDS in an Amazon VPC](services-rds-tutorial.md)
-+ [Configuring the function](#configuration)
+
+- [Tutorial: Configuring a Lambda function to access Amazon RDS in an Amazon VPC](services-rds-tutorial.md)
+- [Configuring the function](#configuration)
 
 ## Configuring the function<a name="configuration"></a>
 
 The following section shows additional configurations and topics we recommend as part of this tutorial\.
-+ If too many function instances run concurrently, one or more instances may fail to obtain a database connection\. You can use reserved concurrency to limit the maximum concurrency of the function\. Set the reserved concurrency to be less than the number of database connections\. Reserved concurrency also reserves those instances for this function, which may not be ideal\. If you are invoking the Lambda functions from your application, we recommend you write code that limits the number of concurrent instances\. For more information, see [Managing concurrency for a Lambda function](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html)\.
-+ For more information on configuring an Amazon RDS database to send notifications, see [Using Amazon RDS event notifications](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html)\. 
-+ For more information on using Amazon SNS as trigger, see [Using AWS Lambda with Amazon SNS](with-sns.md)\.
+
+- If too many function instances run concurrently, one or more instances may fail to obtain a database connection\. You can use reserved concurrency to limit the maximum concurrency of the function\. Set the reserved concurrency to be less than the number of database connections\. Reserved concurrency also reserves those instances for this function, which may not be ideal\. If you are invoking the Lambda functions from your application, we recommend you write code that limits the number of concurrent instances\. For more information, see [Managing concurrency for a Lambda function](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html)\.
+- For more information on configuring an Amazon RDS database to send notifications, see [Using Amazon RDS event notifications](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html)\.
+- For more information on using Amazon SNS as trigger, see [Using AWS Lambda with Amazon SNS](with-sns.md)\.

--- a/doc_source/with-sns.md
+++ b/doc_source/with-sns.md
@@ -4,7 +4,7 @@ You can use a Lambda function to process Amazon Simple Notification Service \(Am
 
 Amazon SNS invokes your function [asynchronously](invocation-async.md) with an event that contains a message and metadata\.
 
-**Example Amazon SNS message event**  
+**Example Amazon SNS message event**
 
 ```
 {
@@ -17,7 +17,7 @@ Amazon SNS invokes your function [asynchronously](invocation-async.md) with an e
         "SignatureVersion": "1",
         "Timestamp": "2019-01-02T12:45:07.000Z",
         "Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
-        "SigningCertUrl": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+        "SigningCertURL": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
         "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
         "Message": "Hello from SNS!",
         "MessageAttributes": {
@@ -31,7 +31,7 @@ Amazon SNS invokes your function [asynchronously](invocation-async.md) with an e
           }
         },
         "Type": "Notification",
-        "UnsubscribeUrl": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-2:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+        "UnsubscribeURL": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-2:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
         "TopicArn":"arn:aws:sns:us-east-2:123456789012:sns-lambda",
         "Subject": "TestInvoke"
       }
@@ -44,15 +44,17 @@ For asynchronous invocation, Lambda queues the message and handles retries\. If 
 
 To perform cross\-account Amazon SNS deliveries to Lambda, you must authorize Amazon SNS to invoke your Lambda function\. In turn, Amazon SNS must allow the AWS account with the Lambda function to subscribe to the Amazon SNS topic\. For example, if the Amazon SNS topic is in account A and the Lambda function is in account B, both accounts must grant permissions to the other to access their respective resources\. Since not all the options for setting up cross\-account permissions are available from the AWS Management Console, you must use the AWS Command Line Interface \(AWS CLI\) for setup\.
 
-For more information, see [Fanout to Lambda functions](https://docs.aws.amazon.com/sns/latest/dg/sns-lambda-as-subscriber.html) in the *Amazon Simple Notification Service Developer Guide*\.
+For more information, see [Fanout to Lambda functions](https://docs.aws.amazon.com/sns/latest/dg/sns-lambda-as-subscriber.html) in the _Amazon Simple Notification Service Developer Guide_\.
 
 **Input types for Amazon SNS events**
 
 For input type examples for Amazon SNS events in Java, \.NET, and Go, see the following on the AWS GitHub repository:
-+ [SNSEvent\.java](https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java)
-+ [SNSEvent\.cs](https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.SNSEvents/SNSEvent.cs)
-+ [sns\.go](https://github.com/aws/aws-lambda-go/blob/master/events/sns.go)
+
+- [SNSEvent\.java](https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java)
+- [SNSEvent\.cs](https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.SNSEvents/SNSEvent.cs)
+- [sns\.go](https://github.com/aws/aws-lambda-go/blob/master/events/sns.go)
 
 **Topics**
-+ [Tutorial: Using AWS Lambda with Amazon Simple Notification Service](with-sns-example.md)
-+ [Sample function code](with-sns-create-package.md)
+
+- [Tutorial: Using AWS Lambda with Amazon Simple Notification Service](with-sns-example.md)
+- [Sample function code](with-sns-create-package.md)

--- a/doc_source/with-sns.md
+++ b/doc_source/with-sns.md
@@ -4,7 +4,7 @@ You can use a Lambda function to process Amazon Simple Notification Service \(Am
 
 Amazon SNS invokes your function [asynchronously](invocation-async.md) with an event that contains a message and metadata\.
 
-**Example Amazon SNS message event**
+**Example Amazon SNS message event**  
 
 ```
 {
@@ -44,17 +44,15 @@ For asynchronous invocation, Lambda queues the message and handles retries\. If 
 
 To perform cross\-account Amazon SNS deliveries to Lambda, you must authorize Amazon SNS to invoke your Lambda function\. In turn, Amazon SNS must allow the AWS account with the Lambda function to subscribe to the Amazon SNS topic\. For example, if the Amazon SNS topic is in account A and the Lambda function is in account B, both accounts must grant permissions to the other to access their respective resources\. Since not all the options for setting up cross\-account permissions are available from the AWS Management Console, you must use the AWS Command Line Interface \(AWS CLI\) for setup\.
 
-For more information, see [Fanout to Lambda functions](https://docs.aws.amazon.com/sns/latest/dg/sns-lambda-as-subscriber.html) in the _Amazon Simple Notification Service Developer Guide_\.
+For more information, see [Fanout to Lambda functions](https://docs.aws.amazon.com/sns/latest/dg/sns-lambda-as-subscriber.html) in the *Amazon Simple Notification Service Developer Guide*\.
 
 **Input types for Amazon SNS events**
 
 For input type examples for Amazon SNS events in Java, \.NET, and Go, see the following on the AWS GitHub repository:
-
-- [SNSEvent\.java](https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java)
-- [SNSEvent\.cs](https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.SNSEvents/SNSEvent.cs)
-- [sns\.go](https://github.com/aws/aws-lambda-go/blob/master/events/sns.go)
++ [SNSEvent\.java](https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java)
++ [SNSEvent\.cs](https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.SNSEvents/SNSEvent.cs)
++ [sns\.go](https://github.com/aws/aws-lambda-go/blob/master/events/sns.go)
 
 **Topics**
-
-- [Tutorial: Using AWS Lambda with Amazon Simple Notification Service](with-sns-example.md)
-- [Sample function code](with-sns-create-package.md)
++ [Tutorial: Using AWS Lambda with Amazon Simple Notification Service](with-sns-example.md)
++ [Sample function code](with-sns-create-package.md)

--- a/sample-apps/java-events/events/sns-notification.json
+++ b/sample-apps/java-events/events/sns-notification.json
@@ -1,31 +1,31 @@
 {
-  "Records": [
-    {
-      "Sns": {
-        "MessageAttributes": {
-          "string-att": {
-            "Type": "String",
-            "Value": "[\"value\", \"value\"]"
-          },
-          "binary-att": {
-            "Type": "Binary",
-            "Value": "WyJ2YWx1ZSIsICJ2YWx1ZSJd"
-          }
-        },
-        "SigningCertURL": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-a86cxmpl4e1f29c941702d737128f7b6.pem",
-        "MessageId": "476643b1-xmpl-526c-973d-1542ba9af1d6",
-        "Message": "Updated and expanded documentation for using Lambda with API Gateway, including support for HTTP APIs.",
-        "Subject": "Latest updates from AWS Lambda",
-        "UnsubscribeURL": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-2:123456789012:java-events-topic:dd15418a-xmpl-4cfd-b418-f7fcb08c7ee4",
-        "Type": "Notification",
-        "SignatureVersion": "1",
-        "Signature": "qZTBXMPL1MoX7HS+m/pg5lRzhJFdaTczB2KqZ6fUCMQGHMF7GhLLTxtC4Hkg2sUysGr14fpDSFRU7MBkzmQmRCXsV9odIHlrxAWvzUuCK2eUnVEoMWJWTH5uyZwWlQHllf9zt2f6eKtEu11yGUqCgzZPfTxg/yu3z/t0EKfdCwDmDL6XqzZbeFvk9uOC1ZIDVv/7cdnbjCslhyx7CTMDnJ7eSu8POgVNIgTItmGFXZDziG1LyV5Afw5fhwObAbypTkfmBSrFuEnDtlQUZvsUCqRJHvdm8g1MmcadSmS1YGBy3OI42oJAmNvfxgZ4/H+KPaXDuvqLNfaZa5qzyRULIg==",
-        "Timestamp": "2020-02-02T12:34:56Z",
-        "TopicArn": "arn:aws:sns:us-east-2:123456789012:java-events-topic"
-      },
-      "EventVersion": "1.0",
-      "EventSource": "aws:sns",
-      "EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:java-events-topic:dd15418a-xmpl-4cfd-b418-f7fcb08c7ee4"
-    }
-  ]
+    "Records": [
+        {
+            "Sns": {
+                "MessageAttributes": {
+                    "string-att": {
+                        "Type": "String",
+                        "Value": "[\"value\", \"value\"]"
+                    },
+                    "binary-att": {
+                        "Type": "Binary",
+                        "Value": "WyJ2YWx1ZSIsICJ2YWx1ZSJd"
+                    }
+                },
+                "SigningCertURL": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-a86cxmpl4e1f29c941702d737128f7b6.pem",
+                "MessageId": "476643b1-xmpl-526c-973d-1542ba9af1d6",
+                "Message": "Updated and expanded documentation for using Lambda with API Gateway, including support for HTTP APIs.",
+                "Subject": "Latest updates from AWS Lambda",
+                "UnsubscribeURL": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-2:123456789012:java-events-topic:dd15418a-xmpl-4cfd-b418-f7fcb08c7ee4",
+                "Type": "Notification",
+                "SignatureVersion": "1",
+                "Signature": "qZTBXMPL1MoX7HS+m/pg5lRzhJFdaTczB2KqZ6fUCMQGHMF7GhLLTxtC4Hkg2sUysGr14fpDSFRU7MBkzmQmRCXsV9odIHlrxAWvzUuCK2eUnVEoMWJWTH5uyZwWlQHllf9zt2f6eKtEu11yGUqCgzZPfTxg/yu3z/t0EKfdCwDmDL6XqzZbeFvk9uOC1ZIDVv/7cdnbjCslhyx7CTMDnJ7eSu8POgVNIgTItmGFXZDziG1LyV5Afw5fhwObAbypTkfmBSrFuEnDtlQUZvsUCqRJHvdm8g1MmcadSmS1YGBy3OI42oJAmNvfxgZ4/H+KPaXDuvqLNfaZa5qzyRULIg==",
+                "Timestamp": "2020-02-02T12:34:56Z",
+                "TopicArn": "arn:aws:sns:us-east-2:123456789012:java-events-topic"
+            },
+            "EventVersion": "1.0",
+            "EventSource": "aws:sns",
+            "EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:java-events-topic:dd15418a-xmpl-4cfd-b418-f7fcb08c7ee4"
+        }
+    ]
 }

--- a/sample-apps/java-events/events/sns-notification.json
+++ b/sample-apps/java-events/events/sns-notification.json
@@ -1,31 +1,31 @@
 {
-    "Records": [
-        {
-            "Sns": {
-                "MessageAttributes": {
-                    "string-att": {
-                        "Type": "String",
-                        "Value": "[\"value\", \"value\"]"
-                    },
-                    "binary-att": {
-                        "Type": "Binary",
-                        "Value": "WyJ2YWx1ZSIsICJ2YWx1ZSJd"
-                    }
-                },
-                "SigningCertUrl": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-a86cxmpl4e1f29c941702d737128f7b6.pem",
-                "MessageId": "476643b1-xmpl-526c-973d-1542ba9af1d6",
-                "Message": "Updated and expanded documentation for using Lambda with API Gateway, including support for HTTP APIs.",
-                "Subject": "Latest updates from AWS Lambda",
-                "UnsubscribeUrl": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-2:123456789012:java-events-topic:dd15418a-xmpl-4cfd-b418-f7fcb08c7ee4",
-                "Type": "Notification",
-                "SignatureVersion": "1",
-                "Signature": "qZTBXMPL1MoX7HS+m/pg5lRzhJFdaTczB2KqZ6fUCMQGHMF7GhLLTxtC4Hkg2sUysGr14fpDSFRU7MBkzmQmRCXsV9odIHlrxAWvzUuCK2eUnVEoMWJWTH5uyZwWlQHllf9zt2f6eKtEu11yGUqCgzZPfTxg/yu3z/t0EKfdCwDmDL6XqzZbeFvk9uOC1ZIDVv/7cdnbjCslhyx7CTMDnJ7eSu8POgVNIgTItmGFXZDziG1LyV5Afw5fhwObAbypTkfmBSrFuEnDtlQUZvsUCqRJHvdm8g1MmcadSmS1YGBy3OI42oJAmNvfxgZ4/H+KPaXDuvqLNfaZa5qzyRULIg==",
-                "Timestamp": "2020-02-02T12:34:56Z",
-                "TopicArn": "arn:aws:sns:us-east-2:123456789012:java-events-topic"
-            },
-            "EventVersion": "1.0",
-            "EventSource": "aws:sns",
-            "EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:java-events-topic:dd15418a-xmpl-4cfd-b418-f7fcb08c7ee4"
-        }
-    ]
+  "Records": [
+    {
+      "Sns": {
+        "MessageAttributes": {
+          "string-att": {
+            "Type": "String",
+            "Value": "[\"value\", \"value\"]"
+          },
+          "binary-att": {
+            "Type": "Binary",
+            "Value": "WyJ2YWx1ZSIsICJ2YWx1ZSJd"
+          }
+        },
+        "SigningCertURL": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-a86cxmpl4e1f29c941702d737128f7b6.pem",
+        "MessageId": "476643b1-xmpl-526c-973d-1542ba9af1d6",
+        "Message": "Updated and expanded documentation for using Lambda with API Gateway, including support for HTTP APIs.",
+        "Subject": "Latest updates from AWS Lambda",
+        "UnsubscribeURL": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-2:123456789012:java-events-topic:dd15418a-xmpl-4cfd-b418-f7fcb08c7ee4",
+        "Type": "Notification",
+        "SignatureVersion": "1",
+        "Signature": "qZTBXMPL1MoX7HS+m/pg5lRzhJFdaTczB2KqZ6fUCMQGHMF7GhLLTxtC4Hkg2sUysGr14fpDSFRU7MBkzmQmRCXsV9odIHlrxAWvzUuCK2eUnVEoMWJWTH5uyZwWlQHllf9zt2f6eKtEu11yGUqCgzZPfTxg/yu3z/t0EKfdCwDmDL6XqzZbeFvk9uOC1ZIDVv/7cdnbjCslhyx7CTMDnJ7eSu8POgVNIgTItmGFXZDziG1LyV5Afw5fhwObAbypTkfmBSrFuEnDtlQUZvsUCqRJHvdm8g1MmcadSmS1YGBy3OI42oJAmNvfxgZ4/H+KPaXDuvqLNfaZa5qzyRULIg==",
+        "Timestamp": "2020-02-02T12:34:56Z",
+        "TopicArn": "arn:aws:sns:us-east-2:123456789012:java-events-topic"
+      },
+      "EventVersion": "1.0",
+      "EventSource": "aws:sns",
+      "EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:java-events-topic:dd15418a-xmpl-4cfd-b418-f7fcb08c7ee4"
+    }
+  ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I noticed the documentation regarding SNS Message fields is a bit inaccurate with `UnsubscribeURL` and `SigningCertURL` from the [SNS Developer's Guide](https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html) specifying `URL` that's all capitalised, but the lambda guide specifying them as `Url`.

In practice, the SNS Message JSON contains the fields `UnsubscribeURL` and `SigningCertURL` with the fully capitalised `URL`, so this PR updated the lambda documentation to match that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
