### PR TITLE
Replace node.js 12 references in template.yml files with node.js 16

### DIFF
--- a/sample-apps/blank-nodejs/template.yml
+++ b/sample-apps/blank-nodejs/template.yml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       CodeUri: function/.
       Description: Call the AWS Lambda API
       Timeout: 10
@@ -25,4 +25,4 @@ Resources:
       Description: Dependencies for the blank sample app.
       ContentUri: lib/.
       CompatibleRuntimes:
-        - nodejs12.x
+        - nodejs16.x

--- a/sample-apps/error-processor/template.yml
+++ b/sample-apps/error-processor/template.yml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: An AWS Lambda application that uses Amazon CloudWatch Logs, AWS X-Ray, and AWS CloudFormation custom resources.
 Globals:
   Function:
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
     Handler: index.handler
     Tracing: Active
     Layers:
@@ -49,7 +49,7 @@ Resources:
       Description: Dependencies for the error-processor sample app.
       ContentUri: lib/.
       CompatibleRuntimes:
-        - nodejs12.x
+        - nodejs16.x
   randomerror:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
ldocs-2093
The Node.js 12 runtime was deprecated on April 30, 2023. References to nodejs12.x runtime in following files replaced with nodejs16.x:

sample-apps/blank-nodejs/template.yml
sample-apps/error-processor/template.yml


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
