### PR TITLE
Telemetry Api: add required header Lambda-Extension-Identifier 

### DIFF
--- a/doc_source/telemetry-api-reference.md
+++ b/doc_source/telemetry-api-reference.md
@@ -19,6 +19,7 @@ To subscribe to a telemetry stream, a Lambda extension can send a Subscribe API 
 + **Method** – `PUT`
 + **Headers**
   + `Content-Type`: `application/json`
+  + `Lambda-Extension-Identifier`: the `Lambda-Extension-Identifier` value received upon registering your extension\.
 + **Request body parameters**
   + **schemaVersion**
     + Required: Yes


### PR DESCRIPTION

*Issue #, if available:*
without this header you get 403 response during subscribing to telemetry stream  
*Description of changes:*
add missing header parameter Lambda-Extension-Identifier required for Telemetry Api


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
