### PR TITLE
CLI command compatibility with v2

### DIFF
--- a/sample-apps/blank-csharp-with-layer/1-create-bucket-and-role.sh
+++ b/sample-apps/blank-csharp-with-layer/1-create-bucket-and-role.sh
@@ -6,7 +6,7 @@ echo $BUCKET_NAME > bucket-name.txt
 aws s3 mb s3://$BUCKET_NAME
 aws s3 mb s3://$LAYER_BUCKET_NAME
 
-aws iam create-role --role-name blank-csharp-role --assume-role-policy-document file://assume-policy.json
+aws iam create-role --role-name blank-csharp-role --assume-role-policy-document fileb://assume-policy.json
 aws iam attach-role-policy --role-name blank-csharp-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 aws iam attach-role-policy --role-name blank-csharp-role --policy-arn arn:aws:iam::aws:policy/AWSLambda_ReadOnlyAccess
 aws iam attach-role-policy --role-name blank-csharp-role --policy-arn arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess

--- a/sample-apps/blank-csharp-with-layer/README.md
+++ b/sample-apps/blank-csharp-with-layer/README.md
@@ -15,14 +15,6 @@ Use the following instructions to deploy the sample application. For more inform
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/blank-csharp/README.md
+++ b/sample-apps/blank-csharp/README.md
@@ -16,14 +16,6 @@ Use the following instructions to deploy the sample application. For more inform
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/blank-go/3-invoke.sh
+++ b/sample-apps/blank-go/3-invoke.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name blank-go --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
 
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   cat out.json
   echo ""
   sleep 2

--- a/sample-apps/blank-go/README.md
+++ b/sample-apps/blank-go/README.md
@@ -15,14 +15,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/blank-java/4-invoke.sh
+++ b/sample-apps/blank-java/4-invoke.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name blank-java --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
 
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   cat out.json
   echo ""
   sleep 2

--- a/sample-apps/blank-java/README.md
+++ b/sample-apps/blank-java/README.md
@@ -20,14 +20,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/blank-nodejs/README.md
+++ b/sample-apps/blank-nodejs/README.md
@@ -25,14 +25,6 @@ Use the following instructions to deploy the sample application. For an in-depth
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/blank-powershell/3-invoke.sh
+++ b/sample-apps/blank-powershell/3-invoke.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name blank-powershell --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
 
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   cat out.json
   echo ""
   sleep 2

--- a/sample-apps/blank-powershell/README.md
+++ b/sample-apps/blank-powershell/README.md
@@ -17,14 +17,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/blank-python/4-invoke.sh
+++ b/sample-apps/blank-python/4-invoke.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name blank-python --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
 
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   cat out.json
   echo ""
   sleep 2

--- a/sample-apps/blank-python/README.md
+++ b/sample-apps/blank-python/README.md
@@ -15,14 +15,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/blank-ruby/4-invoke.sh
+++ b/sample-apps/blank-ruby/4-invoke.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name blank-ruby --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
 
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   cat out.json
   echo ""
   sleep 2

--- a/sample-apps/blank-ruby/README.md
+++ b/sample-apps/blank-ruby/README.md
@@ -15,14 +15,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/ec2-spot/README.md
+++ b/sample-apps/ec2-spot/README.md
@@ -15,14 +15,6 @@ Use the following instructions to deploy the sample application. For more inform
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/efs-nodejs/README.md
+++ b/sample-apps/efs-nodejs/README.md
@@ -32,14 +32,6 @@ To deploy the sample application, you need the following tools:
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 To run the sample application in AWS, you need permission to use Lambda and the following services.
 
 - Amazon EFS ([pricing](https://aws.amazon.com/efs/pricing/))

--- a/sample-apps/error-processor/4-invoke.sh
+++ b/sample-apps/error-processor/4-invoke.sh
@@ -6,14 +6,14 @@ while true; do
   then
     case $1 in
       async)
-        aws lambda invoke --function-name $ERROR_FUNCTION --payload file://event.json --invocation-type Event out.json
+        aws lambda invoke --function-name $ERROR_FUNCTION --payload fileb://event.json --invocation-type Event out.json
         ;;
       *)
         echo -n "Unknown argument"
         ;;
     esac
   else
-    aws lambda invoke --function-name $ERROR_FUNCTION --payload file://event.json out.json
+    aws lambda invoke --function-name $ERROR_FUNCTION --payload fileb://event.json out.json
   fi
   cat out.json
   echo ""

--- a/sample-apps/error-processor/README.md
+++ b/sample-apps/error-processor/README.md
@@ -18,14 +18,6 @@ Use the following instructions to deploy the sample application. For more inform
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/java-basic/3-invoke.sh
+++ b/sample-apps/java-basic/3-invoke.sh
@@ -30,7 +30,7 @@ while true; do
   then
     aws lambda invoke --function-name $FUNCTION --payload $PAYLOAD out.json
   else
-    aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+    aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   fi
   cat out.json
   echo ""

--- a/sample-apps/java-basic/README.md
+++ b/sample-apps/java-basic/README.md
@@ -18,14 +18,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/java-events-v1sdk/4-invoke.sh
+++ b/sample-apps/java-events-v1sdk/4-invoke.sh
@@ -5,10 +5,10 @@ if [ $1 ]
 then
   case $1 in
     ddb)
-      PAYLOAD='file://events/dynamodb-record.json'
+      PAYLOAD='fileb://events/dynamodb-record.json'
       ;;
     kin)
-      PAYLOAD='file://events/kinesis-record.json'
+      PAYLOAD='fileb://events/kinesis-record.json'
       ;;
     *)
       echo -n "Unknown event type"
@@ -20,7 +20,7 @@ while true; do
   then
     aws lambda invoke --function-name $FUNCTION --payload $PAYLOAD out.json
   else
-    aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+    aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   fi
   cat out.json
   echo ""

--- a/sample-apps/java-events-v1sdk/README.md
+++ b/sample-apps/java-events-v1sdk/README.md
@@ -22,14 +22,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/java-events/3-invoke.sh
+++ b/sample-apps/java-events/3-invoke.sh
@@ -5,46 +5,46 @@ if [ $1 ]
 then
   case $1 in
     apig)
-      PAYLOAD='file://events/apigateway-v1.json'
+      PAYLOAD='fileb://events/apigateway-v1.json'
       ;;
     cws)
-      PAYLOAD='file://events/cloudwatch-scheduled.json'
+      PAYLOAD='fileb://events/cloudwatch-scheduled.json'
       ;;
     cwl)
-      PAYLOAD='file://events/cloudwatch-logs.json'
+      PAYLOAD='fileb://events/cloudwatch-logs.json'
       ;;
     sns)
-      PAYLOAD='file://events/sns-notification.json'
+      PAYLOAD='fileb://events/sns-notification.json'
       ;;
     cdn)
-      PAYLOAD='file://events/cloudfront.json'
+      PAYLOAD='fileb://events/cloudfront.json'
       ;;
     cfg)
-      PAYLOAD='file://events/config-rule.json'
+      PAYLOAD='fileb://events/config-rule.json'
       ;;
     cc)
-      PAYLOAD='file://events/codecommit-push.json'
+      PAYLOAD='fileb://events/codecommit-push.json'
       ;;
     cog)
-      PAYLOAD='file://events/cognito-sync.json'
+      PAYLOAD='fileb://events/cognito-sync.json'
       ;;
     kin)
-      PAYLOAD='file://events/kinesis-record.json'
+      PAYLOAD='fileb://events/kinesis-record.json'
       ;;
     fh)
-      PAYLOAD='file://events/firehose-record.json'
+      PAYLOAD='fileb://events/firehose-record.json'
       ;;
     lex)
-      PAYLOAD='file://events/lex-flowers.json'
+      PAYLOAD='fileb://events/lex-flowers.json'
       ;;
     ddb)
-      PAYLOAD='file://events/dynamodb-record.json'
+      PAYLOAD='fileb://events/dynamodb-record.json'
       ;;
     s3)
-      PAYLOAD='file://events/s3-notification.json'
+      PAYLOAD='fileb://events/s3-notification.json'
       ;;
     sqs)
-      PAYLOAD='file://events/sqs-record.json'
+      PAYLOAD='fileb://events/sqs-record.json'
       ;;
     *)
       echo -n "Unknown event type"
@@ -56,7 +56,7 @@ while true; do
   then
     aws lambda invoke --function-name $FUNCTION --payload $PAYLOAD out.json
   else
-    aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+    aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   fi
   cat out.json
   echo ""

--- a/sample-apps/java-events/README.md
+++ b/sample-apps/java-events/README.md
@@ -22,14 +22,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/java17-examples/3-invoke.sh
+++ b/sample-apps/java17-examples/3-invoke.sh
@@ -30,7 +30,7 @@ while true; do
   then
     aws lambda invoke --function-name $FUNCTION --payload $PAYLOAD out.json
   else
-    aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+    aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   fi
   cat out.json
   echo ""

--- a/sample-apps/java17-examples/README.md
+++ b/sample-apps/java17-examples/README.md
@@ -18,14 +18,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/list-manager/5-create-dbtable.sh
+++ b/sample-apps/list-manager/5-create-dbtable.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name list-manager --logical-resource-id dbadmin --query 'StackResourceDetail.PhysicalResourceId' --output text)
-aws lambda invoke --function-name $FUNCTION --payload file://events/db-create-table.json out.json
+aws lambda invoke --function-name $FUNCTION --payload fileb://events/db-create-table.json out.json

--- a/sample-apps/list-manager/6-invoke.sh
+++ b/sample-apps/list-manager/6-invoke.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name list-manager --logical-resource-id processor --query 'StackResourceDetail.PhysicalResourceId' --output text)
 
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://events/kinesis.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload fileb://events/kinesis.json out.json
   cat out.json
   echo ""
   sleep 2

--- a/sample-apps/list-manager/README.md
+++ b/sample-apps/list-manager/README.md
@@ -45,14 +45,6 @@ To deploy the sample application, you need the following tools:
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 To run the sample application in AWS, you need permission to use Lambda and the following services:
 
 - Amazon RDS ([pricing](https://aws.amazon.com/rds/pricing/))

--- a/sample-apps/nodejs-apig/README.md
+++ b/sample-apps/nodejs-apig/README.md
@@ -19,14 +19,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 

--- a/sample-apps/rds-mysql/5-create-dbtable.sh
+++ b/sample-apps/rds-mysql/5-create-dbtable.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name rds-mysql --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
-aws lambda invoke --function-name $FUNCTION --payload file://events/db-create-table.json out.json
+aws lambda invoke --function-name $FUNCTION --payload fileb://events/db-create-table.json out.json

--- a/sample-apps/rds-mysql/6-invoke.sh
+++ b/sample-apps/rds-mysql/6-invoke.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 FUNCTION=$(aws cloudformation describe-stack-resource --stack-name rds-mysql --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
 
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://events/db-read-table.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload fileb://events/db-read-table.json out.json
   cat out.json
   echo ""
   sleep 2

--- a/sample-apps/rds-mysql/README.md
+++ b/sample-apps/rds-mysql/README.md
@@ -34,14 +34,6 @@ To deploy the sample application, you need the following tools:
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 To run the sample application in AWS, you need permission to use Lambda and the following services.
 
 - Amazon RDS ([pricing](https://aws.amazon.com/rds/pricing/))

--- a/sample-apps/s3-java/5-invoke.sh
+++ b/sample-apps/s3-java/5-invoke.sh
@@ -9,7 +9,7 @@ if [ ! -f event.json ]; then
 
 fi
 while true; do
-  aws lambda invoke --function-name $FUNCTION --payload file://event.json out.json
+  aws lambda invoke --function-name $FUNCTION --payload fileb://event.json out.json
   cat out.json
   echo ""
   sleep 2

--- a/sample-apps/s3-java/README.md
+++ b/sample-apps/s3-java/README.md
@@ -19,14 +19,6 @@ Use the following instructions to deploy the sample application.
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) v1.17 or newer.
 
-If you use the AWS CLI v2, add the following to your [configuration file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) (`~/.aws/config`):
-
-```
-cli_binary_format=raw-in-base64-out
-```
-
-This setting enables the AWS CLI v2 to load JSON events from a file, matching the v1 behavior.
-
 # Setup
 Download or clone this repository.
 


### PR DESCRIPTION
*Issue #, if available:* [180](https://github.com/awsdocs/aws-lambda-developer-guide/issues/180)

*Description of changes:* Use `fileb://` instead of `file://` for compatibility with both CLI major versions.
Tested with 3 Node.js samples with latest CLI v1 and v2 builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
