### PR TITLE
Update to latest python version

### DIFF
--- a/sample-apps/blank-python/template.yml
+++ b/sample-apps/blank-python/template.yml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: lambda_function.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.11
       CodeUri: function/.
       Description: Call the AWS Lambda API
       Timeout: 10
@@ -25,4 +25,4 @@ Resources:
       Description: Dependencies for the blank-python sample app.
       ContentUri: package/.
       CompatibleRuntimes:
-        - python3.8
+        - python3.11


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Python3.8 causes a runtime import module error: "Unable to import module 'lambda_function': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
