### PR TITLE
Exclude __pycache__ and pip folders from the layer contents

### DIFF
--- a/sample-apps/layer-python/layer/2-package.sh
+++ b/sample-apps/layer-python/layer/2-package.sh
@@ -1,3 +1,3 @@
 mkdir python
 cp -r create_layer/lib python/
-zip -r layer_content.zip python
+zip -r layer_content.zip python -x "*/__pycache__/*" -x "*/pip*/*"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awsdocs/aws-lambda-developer-guide/issues/473

*Description of changes:* These changes decrease the resulting layer size by x10 and align the example with the AWS docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
